### PR TITLE
MGS 2 | MGS 3: Add patch to skip intro logo images

### DIFF
--- a/MGSHDFix.ini
+++ b/MGSHDFix.ini
@@ -13,6 +13,10 @@ Height = 0
 Windowed = false
 Borderless = false
 
+[Skip Intro Logos]
+; Skips the unskippable KONAMI etc logo images on startup, skippable intro videos will still be played
+Enabled = false
+
 [Disable Mouse Cursor]
 ; Stops the mouse cursor from showing.
 Enabled = true


### PR DESCRIPTION
Added a patch to skip the intro logo images, seems there's some kind of state index kept at 0x14143B160 (MGS3) which normally gets inited to 1 inside 0x1400358C0, then later inside 0x1400358E0 it checks if it's set to 1 and calls 0x140035440 to init the graphics for it etc.

At the end of 0x1400358E0 it sets that index to 3, so I just tried patching the init func to init it to 3 instead of 1 from the start, and seems that was enough to skip the logos, looks like it works fine on both MGS2 and MGS3.

There's still an intro video that plays after the logos which this doesn't currently skip, that video seems to be skippable with spacebar fine though unlike the intro logos, so didn't feel too important to look into, but could still be worth adding something for it eventually.

The code for this is in a separate `SkipIntro` func atm so it could patch the intros before the injection delay kicked in, maybe would be better suited for `Miscellaneous`, but wasn't sure if that delay might stop it from working.  
Not really that familiar with the compiler and memory funcs used here, feel free to let me know if there's anything you'd like changed.