### PR TITLE
Adds support for MG1 / MG2

### DIFF
--- a/MGSHDFix.ini
+++ b/MGSHDFix.ini
@@ -15,6 +15,7 @@ Borderless = false
 
 [Skip Intro Logos]
 ; Skips the unskippable KONAMI etc logo images on startup, skippable intro videos will still be played
+; Skipping logos for MG1 / MG2 (the MSX games) not currently supported.
 Enabled = false
 
 [Disable Mouse Cursor]

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -345,28 +345,32 @@ void DetectGame()
     {
         LOG_F(INFO, "Detected game is: Metal Gear Solid 3 HD");
     }
+    else if (sExeName == "METAL GEAR.exe")
+    {
+        LOG_F(INFO, "Detected game is: Metal Gear / Metal Gear 2 (MSX)");
+    }
 }
 
 void CustomResolution()
 {
-    if (sExeName == "METAL GEAR SOLID2.exe" && bCustomResolution || sExeName == "METAL GEAR SOLID3.exe" && bCustomResolution)
+    if ((sExeName == "METAL GEAR SOLID2.exe" || sExeName == "METAL GEAR SOLID3.exe" || sExeName == "METAL GEAR.exe") && bCustomResolution)
     {
         // MGS 2 | MGS 3: Custom Resolution
         uint8_t* MGS2_MGS3_ResolutionScanResult = Memory::PatternScan(baseModule, "C7 45 ?? 00 05 00 00 C7 ?? ?? D0 02 00 00 C7 ?? ?? 00 05 00 00 C7 ?? ?? D0 02 00 00");
         if (MGS2_MGS3_ResolutionScanResult)
         {
             DWORD64 MGS2_MGS3_ResolutionAddress = (uintptr_t)MGS2_MGS3_ResolutionScanResult + 0x3;
-            LOG_F(INFO, "MGS 2 | MGS 3: Custom Resolution: Address is 0x%" PRIxPTR, (uintptr_t)MGS2_MGS3_ResolutionAddress);
+            LOG_F(INFO, "MG/MG2 | MGS 2 | MGS 3: Custom Resolution: Address is 0x%" PRIxPTR, (uintptr_t)MGS2_MGS3_ResolutionAddress);
 
             Memory::Write(MGS2_MGS3_ResolutionAddress, iCustomResX);
             Memory::Write((MGS2_MGS3_ResolutionAddress + 0x7), iCustomResY);
             Memory::Write((MGS2_MGS3_ResolutionAddress + 0xE), iCustomResX);
             Memory::Write((MGS2_MGS3_ResolutionAddress + 0x15), iCustomResY);
-            LOG_F(INFO, "MGS 2 | MGS 3: Custom Resolution: New Custom Resolution = %dx%d", iCustomResX, iCustomResY);
+            LOG_F(INFO, "MG/MG2 | MGS 2 | MGS 3: Custom Resolution: New Custom Resolution = %dx%d", iCustomResX, iCustomResY);
         }
         else if (!MGS2_MGS3_ResolutionScanResult)
         {
-            LOG_F(INFO, "MGS 2 | MGS 3: Custom Resolution: Pattern scan failed.");
+            LOG_F(INFO, "MG/MG2 | MGS 2 | MGS 3: Custom Resolution: Pattern scan failed.");
         }
 
         // MGS 2 | MGS 3: Framebuffer fix, stops the framebuffer from being set to maximum display resolution.
@@ -377,14 +381,14 @@ void CustomResolution()
             if (MGS2_MGS3_FramebufferFixScanResult)
             {
                 DWORD64 MGS2_MGS3_FramebufferFixAddress = (uintptr_t)MGS2_MGS3_FramebufferFixScanResult + 0x9;
-                LOG_F(INFO, "MGS 2 | MGS 3: Framebuffer %d: Address is 0x%" PRIxPTR, i, (uintptr_t)MGS2_MGS3_FramebufferFixAddress);
+                LOG_F(INFO, "MG/MG2 | MGS 2 | MGS 3: Framebuffer %d: Address is 0x%" PRIxPTR, i, (uintptr_t)MGS2_MGS3_FramebufferFixAddress);
 
                 Memory::PatchBytes(MGS2_MGS3_FramebufferFixAddress, "\x90\x90\x90", 3);
-                LOG_F(INFO, "MGS 2 | MGS 3: Framebuffer %d: Patched instruction.", i);
+                LOG_F(INFO, "MG/MG2 | MGS 2 | MGS 3: Framebuffer %d: Patched instruction.", i);
             }
             else if (!MGS2_MGS3_FramebufferFixScanResult)
             {
-                LOG_F(INFO, "MGS 2 | MGS 3: Framebuffer %d: Pattern scan failed.", i);
+                LOG_F(INFO, "MG/MG2 | MGS 2 | MGS 3: Framebuffer %d: Pattern scan failed.", i);
             }
         }
 
@@ -396,14 +400,14 @@ void CustomResolution()
             if (MGS2_MGS3_WindowModeScanResult)
             {
                 DWORD64 MGS2_MGS3_WindowModeAddress = (uintptr_t)MGS2_MGS3_WindowModeScanResult + 0x7;
-                LOG_F(INFO, "MGS 2 | MGS 3: Window Mode: Address is 0x%" PRIxPTR, (uintptr_t)MGS2_MGS3_WindowModeAddress);
+                LOG_F(INFO, "MG/MG2 | MGS 2 | MGS 3: Window Mode: Address is 0x%" PRIxPTR, (uintptr_t)MGS2_MGS3_WindowModeAddress);
 
                 Memory::PatchBytes(MGS2_MGS3_WindowModeAddress, "\x00", 1);
-                LOG_F(INFO, "MGS 2 | MGS 3: Window Mode: Patched instruction.");
+                LOG_F(INFO, "MG/MG2 | MGS 2 | MGS 3: Window Mode: Patched instruction.");
             }
             else if (!MGS2_MGS3_WindowModeScanResult)
             {
-                LOG_F(INFO, "MGS 2 | MGS 3: Window Mode: Pattern scan failed.");
+                LOG_F(INFO, "MG/MG2 | MGS 2 | MGS 3: Window Mode: Pattern scan failed.");
             }
         }
     }
@@ -427,7 +431,7 @@ void CustomResolution()
             LOG_F(INFO, "MGS 2: Borderless: Pattern scan failed.");
         }
     }
-    else if (sExeName == "METAL GEAR SOLID3.exe" && bBorderlessMode)
+    else if ((sExeName == "METAL GEAR SOLID3.exe" || sExeName == "METAL GEAR.exe") && bBorderlessMode)
     {
         uint8_t* MGS3_CreateWindowExAScanResult = Memory::PatternScan(baseModule, "48 ?? ?? ?? ?? 00 00 4C ?? ?? ?? ?? 48 ?? ?? ?? ?? 44 ?? ?? ?? ??");
         if (MGS3_CreateWindowExAScanResult)
@@ -437,12 +441,12 @@ void CustomResolution()
             MGS3_CreateWindowExAReturnJMP = MGS3_CreateWindowExAAddress + MGS3_CreateWindowExAHookLength;
             Memory::DetourFunction64((void*)MGS3_CreateWindowExAAddress, MGS3_CreateWindowExA_CC, MGS3_CreateWindowExAHookLength);
 
-            LOG_F(INFO, "MGS 3: Borderless: Hook length is %d bytes", MGS3_CreateWindowExAHookLength);
-            LOG_F(INFO, "MGS 3: Borderless: Hook address is 0x%" PRIxPTR, (uintptr_t)MGS3_CreateWindowExAAddress);
+            LOG_F(INFO, "MG/MG2 | MGS 3: Borderless: Hook length is %d bytes", MGS3_CreateWindowExAHookLength);
+            LOG_F(INFO, "MG/MG2 | MGS 3: Borderless: Hook address is 0x%" PRIxPTR, (uintptr_t)MGS3_CreateWindowExAAddress);
         }
         else if (!MGS3_CreateWindowExAScanResult)
         {
-            LOG_F(INFO, "MGS 3: Borderless: Pattern scan failed.");
+            LOG_F(INFO, "MG/MG2 | MGS 3: Borderless: Pattern scan failed.");
         }
     }
     
@@ -503,7 +507,7 @@ void ScaleEffects()
 
 void AspectFOVFix()
 {
-    if (sExeName == "METAL GEAR SOLID3.exe" && bAspectFix)
+    if ((sExeName == "METAL GEAR SOLID3.exe" || sExeName == "METAL GEAR.exe") && bAspectFix)
     {
         // MGS 3: Fix gameplay aspect ratio
         // TODO: Signature is not unique (2 results)
@@ -515,12 +519,12 @@ void AspectFOVFix()
             MGS3_GameplayAspectReturnJMP = MGS3_GameplayAspectAddress + MGS3_GameplayAspectHookLength;
             Memory::DetourFunction64((void*)MGS3_GameplayAspectAddress, MGS3_GameplayAspect_CC, MGS3_GameplayAspectHookLength);
 
-            LOG_F(INFO, "MGS 3: Aspect Ratio: Hook length is %d bytes", MGS3_GameplayAspectHookLength);
-            LOG_F(INFO, "MGS 3: Aspect Ratio: Hook address is 0x%" PRIxPTR, (uintptr_t)MGS3_GameplayAspectAddress);
+            LOG_F(INFO, "MG/MG2 | MGS 3: Aspect Ratio: Hook length is %d bytes", MGS3_GameplayAspectHookLength);
+            LOG_F(INFO, "MG/MG2 | MGS 3: Aspect Ratio: Hook address is 0x%" PRIxPTR, (uintptr_t)MGS3_GameplayAspectAddress);
         }
         else if (!MGS3_GameplayAspectScanResult)
         {
-            LOG_F(INFO, "MGS 3: Aspect Ratio: Pattern scan failed.");
+            LOG_F(INFO, "MG/MG2 | MGS 3: Aspect Ratio: Pattern scan failed.");
         }
     }  
     else if (sExeName == "METAL GEAR SOLID2.exe" && bAspectFix)
@@ -645,7 +649,7 @@ void MovieFix()
 void Miscellaneous()
 {
 
-    if (sExeName == "METAL GEAR SOLID2.exe" && bDisableCursor || sExeName == "METAL GEAR SOLID3.exe" && bDisableCursor)
+    if ((sExeName == "METAL GEAR SOLID2.exe" || sExeName == "METAL GEAR SOLID3.exe" || sExeName == "METAL GEAR.exe") && bDisableCursor)
     {
         // MGS 2 | MGS 3: Disable mouse cursor
         // Thanks again emoose!
@@ -653,14 +657,14 @@ void Miscellaneous()
         if (MGS2_MGS3_MouseCursorScanResult && bWindowedMode)
         {
             DWORD64 MGS2_MGS3_MouseCursorAddress = (uintptr_t)MGS2_MGS3_MouseCursorScanResult;
-            LOG_F(INFO, "MGS 2 | MGS 3: Mouse Cursor: Address is 0x%" PRIxPTR, (uintptr_t)MGS2_MGS3_MouseCursorAddress);
+            LOG_F(INFO, "MG/MG2 | MGS 2 | MGS 3: Mouse Cursor: Address is 0x%" PRIxPTR, (uintptr_t)MGS2_MGS3_MouseCursorAddress);
 
             Memory::PatchBytes(MGS2_MGS3_MouseCursorAddress, "\xEB", 1);
-            LOG_F(INFO, "MGS 2 | MGS 3: Mouse Cursor: Patched instruction.");
+            LOG_F(INFO, "MG/MG2 | MGS 2 | MGS 3: Mouse Cursor: Patched instruction.");
         }
         else if (!MGS2_MGS3_MouseCursorScanResult)
         {
-            LOG_F(INFO, "MGS 2 | MGS 3: Mouse Cursor: Pattern scan failed.");
+            LOG_F(INFO, "MG/MG2 | MGS 2 | MGS 3: Mouse Cursor: Pattern scan failed.");
         }
     }
 


### PR DESCRIPTION
Closes #7

So it turns out MG1 / MG2 just use a modified version of MGS3 that's designed to launch directly into the games (hence why MGS3's save menu is present, and the logos are all the same.)

All functionality that applies to MGS3 works correctly without any modification needed (with the exception of skipping the intro logos, which fails on pattern scan.)

16:9 - 2560x1440
```
File verbosity level: 9
date       time         ( uptime  ) [ thread name/id ]                   file:line     v| 
2023-10-28 20:57:47.645 (   0.000s) [        F95F1D8E]             loguru.cpp:841   INFO| Logging to 'MGSHDFix.log', mode: 'w', verbosity: 9
2023-10-28 20:57:47.645 (   0.000s) [Main            ]            dllmain.cpp:237   INFO| MGSHDFix v0.6 loaded
2023-10-28 20:57:47.646 (   0.001s) [Main            ]            dllmain.cpp:271   INFO| Config Parse: iInjectionDelay: 500ms
2023-10-28 20:57:47.646 (   0.001s) [Main            ]            dllmain.cpp:272   INFO| Config Parse: bCustomResolution: 1
2023-10-28 20:57:47.646 (   0.001s) [Main            ]            dllmain.cpp:273   INFO| Config Parse: iCustomResX: 0
2023-10-28 20:57:47.646 (   0.001s) [Main            ]            dllmain.cpp:274   INFO| Config Parse: iCustomResY: 0
2023-10-28 20:57:47.646 (   0.001s) [Main            ]            dllmain.cpp:275   INFO| Config Parse: bWindowedMode: 1
2023-10-28 20:57:47.646 (   0.001s) [Main            ]            dllmain.cpp:276   INFO| Config Parse: bBorderlessMode: 1
2023-10-28 20:57:47.646 (   0.001s) [Main            ]            dllmain.cpp:277   INFO| Config Parse: bSkipIntroLogos: 1
2023-10-28 20:57:47.646 (   0.001s) [Main            ]            dllmain.cpp:278   INFO| Config Parse: bDisableCursor: 1
2023-10-28 20:57:47.646 (   0.001s) [Main            ]            dllmain.cpp:279   INFO| Config Parse: bMouseSensitivity: 0
2023-10-28 20:57:47.646 (   0.001s) [Main            ]            dllmain.cpp:280   INFO| Config Parse: fMouseSensitivity: 0.00
2023-10-28 20:57:47.646 (   0.001s) [Main            ]            dllmain.cpp:281   INFO| Config Parse: bAspectFix: 1
2023-10-28 20:57:47.646 (   0.001s) [Main            ]            dllmain.cpp:289   INFO| Config Parse: Borderless mode enabled.
2023-10-28 20:57:47.646 (   0.001s) [Main            ]            dllmain.cpp:314   INFO| Custom Resolution: fNewAspect: 1.7778
2023-10-28 20:57:47.646 (   0.001s) [Main            ]            dllmain.cpp:315   INFO| Custom Resolution: fAspectMultiplier: 1.0000
2023-10-28 20:57:47.646 (   0.001s) [Main            ]            dllmain.cpp:316   INFO| Custom Resolution: fHUDWidth: 2560.0000
2023-10-28 20:57:47.646 (   0.001s) [Main            ]            dllmain.cpp:317   INFO| Custom Resolution: fHUDOffset: 0.0000
2023-10-28 20:57:47.646 (   0.001s) [Main            ]            dllmain.cpp:324   INFO| Config Parse: Aspect ratio is native, disabling ultrawide fixes.
2023-10-28 20:57:47.646 (   0.001s) [Main            ]            dllmain.cpp:337   INFO| Game Name: METAL GEAR.exe
2023-10-28 20:57:47.646 (   0.002s) [Main            ]            dllmain.cpp:338   INFO| Game Path: G:\Steam\steamapps\common\MG and MG2\METAL GEAR.exe
2023-10-28 20:57:47.646 (   0.002s) [Main            ]            dllmain.cpp:350   INFO| Detected game is: Metal Gear / Metal Gear 2 (MSX)
2023-10-28 20:57:47.647 (   0.002s) [Main            ]            dllmain.cpp:363   INFO| MG/MG2 | MGS 2 | MGS 3: Custom Resolution: Address is 0x7ff6e189b0e3
2023-10-28 20:57:47.647 (   0.002s) [Main            ]            dllmain.cpp:369   INFO| MG/MG2 | MGS 2 | MGS 3: Custom Resolution: New Custom Resolution = 2560x1440
2023-10-28 20:57:47.647 (   0.003s) [Main            ]            dllmain.cpp:384   INFO| MG/MG2 | MGS 2 | MGS 3: Framebuffer 1: Address is 0x7ff6e18b57de
2023-10-28 20:57:47.647 (   0.003s) [Main            ]            dllmain.cpp:387   INFO| MG/MG2 | MGS 2 | MGS 3: Framebuffer 1: Patched instruction.
2023-10-28 20:57:47.648 (   0.004s) [Main            ]            dllmain.cpp:384   INFO| MG/MG2 | MGS 2 | MGS 3: Framebuffer 2: Address is 0x7ff6e18b583f
2023-10-28 20:57:47.648 (   0.004s) [Main            ]            dllmain.cpp:387   INFO| MG/MG2 | MGS 2 | MGS 3: Framebuffer 2: Patched instruction.
2023-10-28 20:57:47.649 (   0.004s) [Main            ]            dllmain.cpp:403   INFO| MG/MG2 | MGS 2 | MGS 3: Window Mode: Address is 0x7ff6e18b5aaf
2023-10-28 20:57:47.649 (   0.004s) [Main            ]            dllmain.cpp:406   INFO| MG/MG2 | MGS 2 | MGS 3: Window Mode: Patched instruction.
2023-10-28 20:57:47.650 (   0.005s) [Main            ]            dllmain.cpp:444   INFO| MG/MG2 | MGS 3: Borderless: Hook length is 17 bytes
2023-10-28 20:57:47.650 (   0.005s) [Main            ]            dllmain.cpp:445   INFO| MG/MG2 | MGS 3: Borderless: Hook address is 0x7ff6e18b58b5
2023-10-28 20:57:48.164 (   0.519s) [Main            ]            dllmain.cpp:660   INFO| MG/MG2 | MGS 2 | MGS 3: Mouse Cursor: Address is 0x7ff6e18b8cc4
2023-10-28 20:57:48.164 (   0.519s) [Main            ]            dllmain.cpp:663   INFO| MG/MG2 | MGS 2 | MGS 3: Mouse Cursor: Patched instruction.
```

![2023-10-28_20-58-24-METAL_GEAR-METAL_GEAR_2_SOLID_SNAKE](https://github.com/Lyall/MGSHDFix/assets/6209658/53d1cdce-0d79-48de-bc53-92db154b7669)

17:9 - 4096x2160
```
File verbosity level: 9
date       time         ( uptime  ) [ thread name/id ]                   file:line     v| 
2023-10-28 21:11:53.985 (   0.000s) [        CBB8F5EA]             loguru.cpp:841   INFO| Logging to 'MGSHDFix.log', mode: 'w', verbosity: 9
2023-10-28 21:11:53.986 (   0.000s) [Main            ]            dllmain.cpp:237   INFO| MGSHDFix v0.6 loaded
2023-10-28 21:11:53.986 (   0.001s) [Main            ]            dllmain.cpp:271   INFO| Config Parse: iInjectionDelay: 500ms
2023-10-28 21:11:53.987 (   0.001s) [Main            ]            dllmain.cpp:272   INFO| Config Parse: bCustomResolution: 1
2023-10-28 21:11:53.987 (   0.001s) [Main            ]            dllmain.cpp:273   INFO| Config Parse: iCustomResX: 0
2023-10-28 21:11:53.987 (   0.001s) [Main            ]            dllmain.cpp:274   INFO| Config Parse: iCustomResY: 0
2023-10-28 21:11:53.987 (   0.001s) [Main            ]            dllmain.cpp:275   INFO| Config Parse: bWindowedMode: 1
2023-10-28 21:11:53.987 (   0.001s) [Main            ]            dllmain.cpp:276   INFO| Config Parse: bBorderlessMode: 1
2023-10-28 21:11:53.987 (   0.001s) [Main            ]            dllmain.cpp:277   INFO| Config Parse: bSkipIntroLogos: 1
2023-10-28 21:11:53.987 (   0.001s) [Main            ]            dllmain.cpp:278   INFO| Config Parse: bDisableCursor: 1
2023-10-28 21:11:53.987 (   0.001s) [Main            ]            dllmain.cpp:279   INFO| Config Parse: bMouseSensitivity: 0
2023-10-28 21:11:53.987 (   0.001s) [Main            ]            dllmain.cpp:280   INFO| Config Parse: fMouseSensitivity: 0.00
2023-10-28 21:11:53.987 (   0.001s) [Main            ]            dllmain.cpp:281   INFO| Config Parse: bAspectFix: 1
2023-10-28 21:11:53.987 (   0.001s) [Main            ]            dllmain.cpp:289   INFO| Config Parse: Borderless mode enabled.
2023-10-28 21:11:53.987 (   0.001s) [Main            ]            dllmain.cpp:314   INFO| Custom Resolution: fNewAspect: 1.8963
2023-10-28 21:11:53.987 (   0.001s) [Main            ]            dllmain.cpp:315   INFO| Custom Resolution: fAspectMultiplier: 1.0667
2023-10-28 21:11:53.987 (   0.001s) [Main            ]            dllmain.cpp:316   INFO| Custom Resolution: fHUDWidth: 3840.0000
2023-10-28 21:11:53.987 (   0.001s) [Main            ]            dllmain.cpp:317   INFO| Custom Resolution: fHUDOffset: 128.0000
2023-10-28 21:11:53.987 (   0.001s) [Main            ]            dllmain.cpp:337   INFO| Game Name: METAL GEAR.exe
2023-10-28 21:11:53.987 (   0.001s) [Main            ]            dllmain.cpp:338   INFO| Game Path: G:\Steam\steamapps\common\MG and MG2\METAL GEAR.exe
2023-10-28 21:11:53.987 (   0.001s) [Main            ]            dllmain.cpp:350   INFO| Detected game is: Metal Gear / Metal Gear 2 (MSX)
2023-10-28 21:11:53.987 (   0.002s) [Main            ]            dllmain.cpp:363   INFO| MG/MG2 | MGS 2 | MGS 3: Custom Resolution: Address is 0x7ff6e189b0e3
2023-10-28 21:11:53.987 (   0.002s) [Main            ]            dllmain.cpp:369   INFO| MG/MG2 | MGS 2 | MGS 3: Custom Resolution: New Custom Resolution = 4096x2160
2023-10-28 21:11:53.988 (   0.003s) [Main            ]            dllmain.cpp:384   INFO| MG/MG2 | MGS 2 | MGS 3: Framebuffer 1: Address is 0x7ff6e18b57de
2023-10-28 21:11:53.988 (   0.003s) [Main            ]            dllmain.cpp:387   INFO| MG/MG2 | MGS 2 | MGS 3: Framebuffer 1: Patched instruction.
2023-10-28 21:11:53.989 (   0.004s) [Main            ]            dllmain.cpp:384   INFO| MG/MG2 | MGS 2 | MGS 3: Framebuffer 2: Address is 0x7ff6e18b583f
2023-10-28 21:11:53.989 (   0.004s) [Main            ]            dllmain.cpp:387   INFO| MG/MG2 | MGS 2 | MGS 3: Framebuffer 2: Patched instruction.
2023-10-28 21:11:53.990 (   0.004s) [Main            ]            dllmain.cpp:403   INFO| MG/MG2 | MGS 2 | MGS 3: Window Mode: Address is 0x7ff6e18b5aaf
2023-10-28 21:11:53.990 (   0.004s) [Main            ]            dllmain.cpp:406   INFO| MG/MG2 | MGS 2 | MGS 3: Window Mode: Patched instruction.
2023-10-28 21:11:53.991 (   0.005s) [Main            ]            dllmain.cpp:444   INFO| MG/MG2 | MGS 3: Borderless: Hook length is 17 bytes
2023-10-28 21:11:53.991 (   0.005s) [Main            ]            dllmain.cpp:445   INFO| MG/MG2 | MGS 3: Borderless: Hook address is 0x7ff6e18b58b5
2023-10-28 21:11:54.502 (   0.517s) [Main            ]            dllmain.cpp:522   INFO| MG/MG2 | MGS 3: Aspect Ratio: Hook length is 15 bytes
2023-10-28 21:11:54.502 (   0.517s) [Main            ]            dllmain.cpp:523   INFO| MG/MG2 | MGS 3: Aspect Ratio: Hook address is 0x7ff6e1895e8c
2023-10-28 21:11:54.504 (   0.519s) [Main            ]            dllmain.cpp:660   INFO| MG/MG2 | MGS 2 | MGS 3: Mouse Cursor: Address is 0x7ff6e18b8cc4
2023-10-28 21:11:54.504 (   0.519s) [Main            ]            dllmain.cpp:663   INFO| MG/MG2 | MGS 2 | MGS 3: Mouse Cursor: Patched instruction.
```
![image](https://github.com/Lyall/MGSHDFix/assets/6209658/fd314943-c5b6-450c-9455-6bdcf3e47457)
