### PR TITLE
Add Linux/Steam Deck specific instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ This is a **work-in-progress** fix that aims to add custom resolutions and ultra
 - Grab the latest release of MGSHDFix from [here.](https://github.com/Lyall/MGSHDFix/releases)
 - Extract the contents of the release zip in to the the game folder.<br />(e.g. "**steamapps\common\MGS2**" or "**steamapps\common\MGS3**" for Steam).
 
+### Steam Deck/Linux additional instructions
+Steam Deck users can also enjoy a native 800p (16:10) experience by installing this mod.
+- Open up the Steam properties of either MGS2/MGS3 and put `WINEDLLOVERRIDES="d3d11=n,b" %command%` in the launch options.
+- If you're using the missing audio workaround put `WINEDLLOVERRIDES="xaudio2_9=n;d3d11=n,b" %command%` instead.
+
 ## Configuration
 - See **MGSHDFix.ini** to adjust settings for the fix.
 


### PR DESCRIPTION
Steam Deck users might want to use this to get rid of black bars on their 16:10 display. And Linux users through Proton would enjoy this mod too, so this PR is for adding quick instructions on the README.md