### PR TITLE
MGS2/MGS3: add hook/setting for anisotropic filtering

### DIFF
--- a/MGSHDFix.ini
+++ b/MGSHDFix.ini
@@ -12,7 +12,7 @@ Width = 0
 Height = 0
 Windowed = false
 Borderless = false
-; Anisotropic Filtering: valid values are 0 / 2 / 4 / 8 / 16
+; Anisotropic Filtering: valid values are 0 - 16
 ; Experimental, may take effect on more textures than it should
 Anisotropic Filtering = 0
 

--- a/MGSHDFix.ini
+++ b/MGSHDFix.ini
@@ -13,6 +13,7 @@ Height = 0
 Windowed = false
 Borderless = false
 ; Anisotropic Filtering: valid values are 0 / 2 / 4 / 8 / 16
+; Experimental, may take effect on more textures than it should
 Anisotropic Filtering = 0
 
 [Framebuffer Fix]

--- a/MGSHDFix.ini
+++ b/MGSHDFix.ini
@@ -12,6 +12,8 @@ Width = 0
 Height = 0
 Windowed = false
 Borderless = false
+; Anisotropic Filtering: valid values are 0 / 2 / 4 / 8 / 16
+Anisotropic Filtering = 0
 
 [Framebuffer Fix]
 ; Forces the framebuffer size to be the same as the custom resolution.

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -860,16 +860,25 @@ void Miscellaneous()
     if (iAnisotropicFiltering > 0 && (sExeName == "METAL GEAR SOLID3.exe" || sExeName == "METAL GEAR SOLID2.exe"))
     {
         uint8_t* MGS2_MGS3_SetSamplerStateInsnResult = Memory::PatternScan(baseModule, "48 8B 05 ?? ?? ?? ?? 44 39 8C 01 38 04 00 00");
-        if (MGS2_MGS3_SetSamplerStateInsnResult)
+        if (!MGS2_MGS3_SetSamplerStateInsnResult)
         {
             DWORD64 MGS2_MGS3_SetSamplerStateInsnAddress = (uintptr_t)MGS2_MGS3_SetSamplerStateInsnResult;
             DWORD64 gpRenderBackendPtrAddr = MGS2_MGS3_SetSamplerStateInsnAddress + 3;
 
             gpRenderBackend = *(int*)gpRenderBackendPtrAddr + gpRenderBackendPtrAddr + 4;
+            LOG_F(INFO, "MGS 2 | MGS 3: Anisotropic Filtering: gpRenderBackend = 0x%" PRIxPTR, (uintptr_t)gpRenderBackend);
 
             int MGS2_MGS3_SetSamplerStateInsnHookLength = Memory::GetHookLength((char*)MGS2_MGS3_SetSamplerStateInsnAddress, 14);
+
+            LOG_F(INFO, "MGS 2 | MGS 3: Anisotropic Filtering: Hook length is %d bytes", MGS2_MGS3_SetSamplerStateInsnHookLength);
+            LOG_F(INFO, "MGS 2 | MGS 3: Anisotropic Filtering: Hook address is 0x%" PRIxPTR, (uintptr_t)MGS2_MGS3_SetSamplerStateInsnAddress);
+
             MGS2_MGS3_SetSamplerStateAnisoReturnJMP = MGS2_MGS3_SetSamplerStateInsnAddress + MGS2_MGS3_SetSamplerStateInsnHookLength;
             Memory::DetourFunction64((void*)MGS2_MGS3_SetSamplerStateInsnAddress, MGS2_MGS3_SetSamplerStateAniso_CC, MGS2_MGS3_SetSamplerStateInsnHookLength);
+        }
+        else
+        {
+            LOG_F(INFO, "MGS 2 | MGS 3: Anisotropic Filtering: Sampler state pattern scan failed.");
         }
     }
 

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -865,7 +865,7 @@ void Miscellaneous()
     if (iAnisotropicFiltering > 0 && (sExeName == "METAL GEAR SOLID3.exe" || sExeName == "METAL GEAR SOLID2.exe"))
     {
         uint8_t* MGS2_MGS3_SetSamplerStateInsnResult = Memory::PatternScan(baseModule, "48 8B 05 ?? ?? ?? ?? 44 39 8C 01 38 04 00 00");
-        if (!MGS2_MGS3_SetSamplerStateInsnResult)
+        if (MGS2_MGS3_SetSamplerStateInsnResult)
         {
             DWORD64 MGS2_MGS3_SetSamplerStateInsnAddress = (uintptr_t)MGS2_MGS3_SetSamplerStateInsnResult;
             DWORD64 gpRenderBackendPtrAddr = MGS2_MGS3_SetSamplerStateInsnAddress + 3;

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -358,6 +358,11 @@ void ReadConfig()
     LOG_F(INFO, "Config Parse: bWindowedMode: %d", bWindowedMode);
     LOG_F(INFO, "Config Parse: bBorderlessMode: %d", bBorderlessMode);
     LOG_F(INFO, "Config Parse: iAnisotropicFiltering: %d", iAnisotropicFiltering);
+    if (iAnisotropicFiltering < 0 || iAnisotropicFiltering > 16)
+    {
+        iAnisotropicFiltering = std::clamp(iAnisotropicFiltering, 0, 16);
+        LOG_F(INFO, "Config Parse: iAnisotropicFiltering value invalid, clamped to %d", iAnisotropicFiltering);
+    }
     LOG_F(INFO, "Config Parse: bFramebufferFix: %d", bFramebufferFix);
     LOG_F(INFO, "Config Parse: bSkipIntroLogos: %d", bSkipIntroLogos);
     LOG_F(INFO, "Config Parse: bDisableCursor: %d", bDisableCursor);


### PR DESCRIPTION
Game currently doesn't apply any kind of anisotropic filtering, leaving textures get very muddy in the distance, there's some ways to force this in driver settings but not sure how perfect driver forcing is (and a lot of people probably don't know they can force it via drivers)

In D3D11 it seems for anisotropy to be used a D3D11_SAMPLER_DESC has to be setup with both `.Filter = D3D11_FILTER_ANISOTROPIC` and also `.MaxAnisotropy = anisoAmount`

Fortunately for us it looks like game already creates D3D11_SAMPLER_DESC instances already, and uses them with CreateSamplerState etc, but it's only applying worse filters like `D3D11_FILTER_MIN_MAG_MIP_POINT / D3D11_FILTER_MIN_LINEAR_MAG_MIP_POINT`, etc...

(in MGS3 0x14004D310 / `CRenderBackend::SetTextureFilter` chooses one of those filters above, and 0x140055DE0 / `CD3DCachedDevice::SetSamplerState` then sets it in the D3D11_SAMPLER_DESC struct)

Sadly we can't just patch the ID of those filters being used over to D3D11_FILTER_ANISOTROPIC since we also have to setup the .MaxAnisotropy field of it too, best way I could find for that was a hook inside `SetSamplerState` when it's setting up the .Filter field, there wasn't really much room there to hook but was able to find a way to get it working, and also keep the small optimization they use in that func so it only applies the filter when it's being changed from previous one.

Anisotropy makes a pretty big difference in MGS3, before:

![23-10-30_00-06-41-097_METAL_GEAR_SOLID3](https://github.com/Lyall/MGSHDFix/assets/1755499/e8c19d71-de6d-407c-b2f9-2f226d64976f)

after:

![23-10-30_00-08-02-535_METAL_GEAR_SOLID3](https://github.com/Lyall/MGSHDFix/assets/1755499/d22638b3-ac3c-4c63-bcf2-da7002d255ad)

The hook seems to apply fine in MGS2 too but I couldn't really notice much difference there, guess the camera maybe makes it harder to see...

This might need more testing before being merged, haven't really got that far in the games yet so only tried it around starting areas, maybe something later on could break with it.

If anyone wants to help test it here's a build with it included, install on top of 0.7 & edit the INI to enable it: 
[MGSHDFix-aniso-fixed.zip](https://github.com/Lyall/MGSHDFix/files/13222802/MGSHDFix-aniso-fixed.zip)

(E: build should have fixed pattern scan now)