### PR TITLE
MG1/2 | MGS3: Add patches to extend texture buffer size

### DIFF
--- a/MGSHDFix.ini
+++ b/MGSHDFix.ini
@@ -44,6 +44,11 @@ Enabled = false
 X Multiplier = 1
 Y Multiplier = 1
 
+[Texture Buffer]
+; MG1/2 | MGS3: Extends size of the temporary texture buffer used by the game, allowing textures larger than 16MB to be loaded
+; Setting to the game default of 16 or lower will disable extending
+SizeMB = 128
+
 ;;;;;; Ultrawide Fixes ;;;;;;
 
 [Fix Aspect Ratio]


### PR DESCRIPTION
Fixes #15

Allows extending the temporary texture buffer that both MG1/2 & MGS3 seem to use, allowing larger texture files to be loaded into the game.

Seems MGS2 doesn't use this kind of temporary buffer, all the same CTexture/CBaseTexture code is there but the code around this temporary buffer stuff is missing, weird (maybe after they worked on MGS2 they added this buffer trick as an optimization during MGS3 work, but then forgot to backport it to MGS2, who knows)

MG1/2 does include the same buffer code but doubtful it can make much difference there, still added it just in case someone wants to use a 50MB intro logo or something :P

Haven't tried comparing memory usage with this yet, AFAIK it should only be allocing the main buffer once per session, so would add 128 - 16 = ~112MB extra usage, there is that weird mip count part which I'm not sure of though, maybe would increase it more.

One small worry with this is that it's kinda tying data files with HDFix, if you installed HDFix along with a larger-than-16MB texture pack, removing HDFix while keeping the texture pack files would cause crashing in the vanilla game...  
Can't really see much way to get around that though, and guess users can always verify files in steam to fix it, so maybe not a huge problem.