### PR TITLE
Log: write EXE timestamp to log file

### DIFF
--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -470,6 +470,7 @@ void DetectGame()
 
     LOG_F(INFO, "Game Name: %s", sExeName.c_str());
     LOG_F(INFO, "Game Path: %s", sExePath.c_str());
+    LOG_F(INFO, "Game Timestamp: %u", Memory::ModuleTimestamp(baseModule)); // TODO: convert from unix timestamp to string, store in sGameVersion?
 
     if (sExeName == "METAL GEAR SOLID2.exe")
     {

--- a/src/helper.hpp
+++ b/src/helper.hpp
@@ -120,6 +120,13 @@ namespace Memory
         return len ? (HMODULE)info.AllocationBase : NULL;
     }
 
+    uint32_t ModuleTimestamp(void* module)
+    {
+        auto dosHeader = (PIMAGE_DOS_HEADER)module;
+        auto ntHeaders = (PIMAGE_NT_HEADERS)((std::uint8_t*)module + dosHeader->e_lfanew);
+        return ntHeaders->FileHeader.TimeDateStamp;
+    }
+
     // CSGOSimple's pattern scan
     // https://github.com/OneshotGH/CSGOSimple-master/blob/master/CSGOSimple/helpers/utils.cpp
     std::uint8_t* PatternScan(void* module, const char* signature)


### PR DESCRIPTION
Just writes out the timestamp from EXE header into log file, so we can know what version people are using when they post logs.

Could probably grab version string from the EXE resources instead, but that needs a bunch of Win32 calls to fetch the resources, had some weird issues with that in the past too, EXE header timestamp is probably good enough for now (and would probably be more reliable to find what EXE was being used, instead of the version resource which is the same between JP/US versions...)