### PR TITLE
DllMain: make game wait for us to finish, add `SkipLauncher` setting

### DIFF
--- a/MGSHDFix.ini
+++ b/MGSHDFix.ini
@@ -13,6 +13,16 @@ Height = 0
 Windowed = false
 Borderless = false
 
+[Launcher Config]
+; If enabled will skip the launcher app and run the game directly
+; (options like game language & button style will need to be configured below)
+SkipLauncher = false
+
+; CtrlType: 0 = PS5, 1 = PS4, 2 = XBOX, 3 = NX, 4 = STMD, 5 = KBD
+CtrlType = 5
+Region = 0
+Language = 0
+
 [Anisotropic Filtering]
 ; Anisotropic Filtering: valid values are 0 - 16
 ; Experimental, may take effect on more textures than it should

--- a/MGSHDFix.ini
+++ b/MGSHDFix.ini
@@ -14,10 +14,12 @@ Borderless = false
 ; (options like game language & button style will need to be configured below)
 SkipLauncher = false
 
-; CtrlType: 0 = PS5, 1 = PS4, 2 = XBOX, 3 = NX, 4 = STMD, 5 = KBD
-CtrlType = 5
-Region = 0
-Language = 0
+; CtrlType: PS5, PS4, XBOX, NX, STMD, KBD
+CtrlType = KBD
+; Language (may depend on Region setting): EN, JP, FR, GR, IT, PR, SP, DU, RU
+Language = EN
+; Region (MGS3 only): US, JP, EU
+Region = US
 
 [Anisotropic Filtering]
 ; Anisotropic Filtering: valid values are 0 - 16

--- a/MGSHDFix.ini
+++ b/MGSHDFix.ini
@@ -1,7 +1,3 @@
-[MGSHDFix Parameters]
-; Injection delay in milliseconds.
-InjectionDelay = 500
-
 ;;;;;;;;;; General ;;;;;;;;;;
 
 [Custom Resolution]

--- a/MGSHDFix.vcxproj
+++ b/MGSHDFix.vcxproj
@@ -136,6 +136,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -154,6 +155,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/MGSHDFix.vcxproj
+++ b/MGSHDFix.vcxproj
@@ -90,6 +90,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetExt>.asi</TargetExt>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetExt>.asi</TargetExt>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
@@ -132,6 +135,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -26,7 +26,6 @@ float fMouseSensitivityXMulti;
 float fMouseSensitivityYMulti;
 int iCustomResX;
 int iCustomResY;
-int iInjectionDelay;
 bool bLauncherConfigSkipLauncher = false;
 int iLauncherConfigCtrlType = 5;
 int iLauncherConfigRegion = 0;
@@ -407,7 +406,6 @@ void ReadConfig()
         ini.parse(iniFile);
     }
 
-    inipp::get_value(ini.sections["MGSHDFix Parameters"], "InjectionDelay", iInjectionDelay);
     inipp::get_value(ini.sections["Custom Resolution"], "Enabled", bCustomResolution);
     inipp::get_value(ini.sections["Custom Resolution"], "Width", iCustomResX);
     inipp::get_value(ini.sections["Custom Resolution"], "Height", iCustomResY);
@@ -431,7 +429,6 @@ void ReadConfig()
     inipp::get_value(ini.sections["Launcher Config"], "Language", iLauncherConfigLanguage);
 
     // Log config parse
-    LOG_F(INFO, "Config Parse: iInjectionDelay: %dms", iInjectionDelay);
     LOG_F(INFO, "Config Parse: bCustomResolution: %d", bCustomResolution);
     LOG_F(INFO, "Config Parse: iCustomResX: %d", iCustomResX);
     LOG_F(INFO, "Config Parse: iCustomResY: %d", iCustomResY);
@@ -1350,7 +1347,6 @@ DWORD __stdcall Main(void*)
         LauncherConfigOverride();
         CustomResolution();
         IntroSkip();
-        Sleep(iInjectionDelay);
         ScaleEffects();
         AspectFOVFix();
         HUDFix();

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <iostream>
 #include <inttypes.h>
+#include <mutex>
 
 #include "external/loguru/loguru.hpp"
 #include "external/inipp/inipp/inipp.h"

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <inttypes.h>
 #include <mutex>
+#include <filesystem>
 
 #include "external/loguru/loguru.hpp"
 #include "external/inipp/inipp/inipp.h"


### PR DESCRIPTION
ATM we use CreateThread from DllMain to spawn a thread for our Main to execute in, unfortunately while that thread is running it seems games main thread is also executing, which can cause a race between our patches being applied & the game running the code we're patching, seen this cause issues already with the texture buffer patch :/

Tried running our Main directly from DllMain instead and that seemed to work fine, but I know there's issues it can run into with loader lock etc, which is probably why CreateThread was used there instead.

In the past I've got around this by hooking one of the imports that are called near games entrypoint, `GetSystemTimeAsFileTime` / `GetStartupInfoW` etc are usually called by the VC runtime built into game exe very early on, but sadly it seems ASI loader is also hooking those, and some reason they're only unhooked after ASI plugins have been loaded, so they're still hooked by it during our DllMain ;_;

Luckily it looks like one of the funcs called by WinMain does call into `memset` imported from `vcruntime140` very early on, checked all 3 games and they all shared the same call there, added stuff to hook the IAT for that instead and it all seems to work fine.

With this our Main func should fully run before the game does anything important, maybe we can remove the `iInjectionDelay` Sleep stuff now too, but haven't changed that in here in case it's needed for something.

Heard from a couple people that this helped fix the crashing with larger textures, hopefully all our hooks should still work fine too.