### PR TITLE
LauncherConfig: add settings for MG1/MG2

### DIFF
--- a/MGSHDFix.ini
+++ b/MGSHDFix.ini
@@ -21,6 +21,13 @@ Language = EN
 ; Region (MGS3 only): US, JP, EU
 Region = US
 
+; MSXGame (MG1/MG2 only): which MSX game to launch, MG1 or MG2
+MSXGame = MG1
+; MSXWallType (MG1/MG2 only): which wallpaper style to use (0 to 6)
+MSXWallType = 0
+; MSXWallAlign (MG1/MG2 only): orientation of game screen (L, R, or C for center)
+MSXWallAlign = C
+
 [Anisotropic Filtering]
 ; Anisotropic Filtering: valid values are 0 - 16
 ; Experimental, may take effect on more textures than it should

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -13,6 +13,7 @@
 #include <inttypes.h>
 #include <mutex>
 #include <filesystem>
+#include <codecvt>
 
 #include "external/loguru/loguru.hpp"
 #include "external/inipp/inipp/inipp.h"


### PR DESCRIPTION
Ah forgot about these, added a fix that just adds the params for them to the CreateProcess command-line, should let them work fine with SkipLauncher now.

(seems these params are handled by the main EXE instead of being passed to Engine.dll, so would probably need a bit more work to handle them the same way we do for ctrltype/region/etc, adding params to CreateProcess seemed good enough to get SkipLauncher to work, but atm they won't take effect if the game EXE is ran directly)