### PR TITLE
Fixes High DPI scaling bug & monitors going to sleep during cutscenes

### DIFF
--- a/MGSHDFix.ini
+++ b/MGSHDFix.ini
@@ -39,6 +39,11 @@ MSXWallAlign = C
 ; Experimental, may take effect on more textures than it should
 Samples = 16
 
+[DPI Scaling Fix]
+; Fixes the game's window being zoomed in on monitors with DPI scaling enabled.
+; You will generally always want to keep this enabled.
+Enabled = true
+
 [Framebuffer Fix]
 ; Forces the framebuffer size to be the same as the custom resolution.
 ; Disable this if you want pillarboxing/letterboxing with your custom resolution.

--- a/MGSHDFix.ini
+++ b/MGSHDFix.ini
@@ -39,11 +39,6 @@ MSXWallAlign = C
 ; Experimental, may take effect on more textures than it should
 Samples = 16
 
-[DPI Scaling Fix]
-; Fixes the game's window being zoomed in on monitors with DPI scaling enabled.
-; You will generally always want to keep this enabled.
-Enabled = true
-
 [Framebuffer Fix]
 ; Forces the framebuffer size to be the same as the custom resolution.
 ; Disable this if you want pillarboxing/letterboxing with your custom resolution.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ This is a fix that adds custom resolutions, ultrawide support and much more to t
 - Borderless/windowed mode.
 - Mouse cursor toggle.
 - Mouse sensitivity adjustment (MGS3).
-- Correct gameplay/cutscene aspect ratio (MGS2/MGS3).
+- Corrects gameplay/cutscene aspect ratio (MGS2/MGS3).
+- Corrects window size on displays with High DPI scaling enabled. #127
 - Launcher skip (see ini to configure).
 - Skip intro logos (MGS2/MGS3).
 - Adjustable anisotropic filtering (MGS2/MGS3).
@@ -43,7 +44,6 @@ This list will contain bugs which may or may not be fixed.
 ### MGS 2
 - Strength of post-processing may be reduced at higher resolutions. ([#35](https://github.com/Lyall/MGSHDFix/issues/35))
 - Various visual issues when using the experimental HUD fix. ([#41](https://github.com/Lyall/MGSHDFix/issues/41))
-- Prerendered camera pictures are black. ([#60](https://github.com/Lyall/MGSHDFix/issues/60))
 - Vector based graphic effects (such as rain) do not get scaled up at higher resolutions. ([#90](https://github.com/Lyall/MGSHDFix/issues/90) & [#96](https://github.com/Lyall/MGSHDFix/issues/96))
 
 ### MGS 3
@@ -62,7 +62,7 @@ This list will contain bugs which may or may not be fixed.
 | Metal Gear Solid 3 |
 
 ## Credits
-[@emoose](https://github.com/emoose) & [@cipherxof](https://github.com/cipherxof) for contributing fixes. <br />
+[@emoose](https://github.com/emoose), [@cipherxof](https://github.com/cipherxof), & [@ShizCalev/Afevis](https://github.com/shizcalev) for contributing fixes. <br />
 [Ultimate ASI Loader](https://github.com/ThirteenAG/Ultimate-ASI-Loader) for ASI loading. <br />
 [inipp](https://github.com/mcmtroffaes/inipp) for ini reading. <br />
 [spdlog](https://github.com/gabime/spdlog) for logging. <br />

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This is a fix that adds custom resolutions, ultrawide support and much more to t
 - Mouse sensitivity adjustment (MGS3).
 - Corrects gameplay/cutscene aspect ratio (MGS2/MGS3).
 - Corrects window size on displays with High DPI scaling enabled. #127
+- Corrects the monitor going to sleep during long cutscenes.
 - Launcher skip (see ini to configure).
 - Skip intro logos (MGS2/MGS3).
 - Adjustable anisotropic filtering (MGS2/MGS3).

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -1411,6 +1411,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             SetThreadPriority(mainHandle, THREAD_PRIORITY_HIGHEST); // set our Main thread priority higher than the games thread
             CloseHandle(mainHandle);
         }
+        SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED); //fixes the monitor going to sleep during cutscenes.
     }
     case DLL_THREAD_ATTACH:
     case DLL_THREAD_DETACH:

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -35,7 +35,6 @@ int iInternalResX;
 int iInternalResY;
 bool bWindowedMode;
 bool bBorderlessMode;
-bool bDPIScalingFix;
 bool bFramebufferFix;
 bool bSkipIntroLogos;
 int iAnisotropicFiltering;
@@ -314,7 +313,6 @@ void ReadConfig()
     inipp::get_value(ini.sections["Internal Resolution"], "Width", iInternalResX);
     inipp::get_value(ini.sections["Internal Resolution"], "Height", iInternalResY);
     inipp::get_value(ini.sections["Anisotropic Filtering"], "Samples", iAnisotropicFiltering);
-    inipp::get_value(ini.sections["DPI Scaling Fix"], "Enabled", bDPIScalingFix);
     inipp::get_value(ini.sections["Framebuffer Fix"], "Enabled", bFramebufferFix);
     inipp::get_value(ini.sections["Skip Intro Logos"], "Enabled", bSkipIntroLogos);
     inipp::get_value(ini.sections["Mouse Sensitivity"], "Enabled", bMouseSensitivity);
@@ -363,7 +361,6 @@ void ReadConfig()
         iAnisotropicFiltering = std::clamp(iAnisotropicFiltering, 0, 16);
         spdlog::info("Config Parse: iAnisotropicFiltering value invalid, clamped to {}", iAnisotropicFiltering);
     }
-    spdlog::info("Config Parse: bDPIScalingFix: {}", bDPIScalingFix);
     spdlog::info("Config Parse: bFramebufferFix: {}", bFramebufferFix);
     spdlog::info("Config Parse: bSkipIntroLogos: {}", bSkipIntroLogos);
     spdlog::info("Config Parse: bMouseSensitivity: {}", bMouseSensitivity);
@@ -424,7 +421,7 @@ bool DetectGame()
 
 void FixDPIScaling()
 {
-    if (bDPIScalingFix && (eGameType == MgsGame::MGS2 || eGameType == MgsGame::MGS3 || eGameType == MgsGame::MG)){
+    if (eGameType == MgsGame::MGS2 || eGameType == MgsGame::MGS3 || eGameType == MgsGame::MG){
         SetProcessDPIAware();
         spdlog::info("MG/MG2 | MGS 2 | MGS 3: High-DPI scaling fixed.");
     }


### PR DESCRIPTION
Fixes this bug on systems with DPI scaling enabled

https://github.com/Lyall/MGSHDFix/issues/106#issuecomment-2381030254
https://github.com/Lyall/MGSHDFix/issues/4#issuecomment-1788238252

![371813138-b6a9ea89-aff4-4ec7-828a-e9013bfd4983](https://github.com/user-attachments/assets/b139b0e4-69d6-438b-b015-4148ad081ce0)

Also removed #60 from the readme since it was fixed officially by Konami.