### PR TITLE
Fixes framebuffer fix not applying to MG1/MG2

### DIFF
--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -11,7 +11,7 @@ HMODULE unityPlayer;
 
 // Version
 string sFixName = "MGSHDFix";
-string sFixVer = "2.3.1";
+string sFixVer = "2.3.3";
 
 // Logger
 std::shared_ptr<spdlog::logger> logger;
@@ -569,7 +569,7 @@ void CustomResolution()
             {
                 spdlog::info("MG/MG2 | MGS 2 | MGS 3: Windowed Framebuffer: Address is {:s}+{:x}", sExeName.c_str(), (uintptr_t)MGS2_MGS3_WindowedFramebufferFixScanResult - (uintptr_t)baseModule);
                 Memory::PatchBytes((uintptr_t)MGS2_MGS3_WindowedFramebufferFixScanResult, "\xEB", 1);
-                if (eGameType == MgsGame::MGS3)
+                if (eGameType == MgsGame::MGS3 || eGameType == MgsGame::MG)
                     Memory::PatchBytes((uintptr_t)MGS2_MGS3_WindowedFramebufferFixScanResult + 0x2A, "\xEB", 1);
                 if (eGameType == MgsGame::MGS2)
                     Memory::PatchBytes((uintptr_t)MGS2_MGS3_WindowedFramebufferFixScanResult + 0x27, "\xEB", 1);


### PR DESCRIPTION
I had previously fixed this at an OS level so I didn't realize it wasn't functioning properly till now lol

Fixes #133
Fixes #101
![2131680_20250326155419_1](https://github.com/user-attachments/assets/0d853a7f-8461-4481-b79e-9993b14787db)

