### PR TITLE
Fix 1px-wide vector lines

### DIFF
--- a/MGSHDFix.ini
+++ b/MGSHDFix.ini
@@ -86,6 +86,7 @@ Enabled = true
 ; which weren't properly scaled up from their PS2 resolutions.
 ; Generally want to keep this to false. 
 Disable = false
-; Scaling Size: Lower numbers increase the width of vector effects at 1/scale (ie 1/512, or 0.001953125)
-; 512 makes line widths identical in scale to PCSX2's corrected line widths.
-Line Scale = 512
+; Scaling Size: Lower numbers increase the width of vector effects at 1/scale (ie 1/480, or 0.00208333333)
+; 480 makes line widths identical in scale to PCSX2's corrected line widths, given the native res of 640 by ->480<-
+; At 1080p this would result in lines being approx 2-3 pixels thick.
+Line Scale = 480

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ This is a fix that adds custom resolutions, ultrawide support and much more to t
 - Grab the latest release of MGSHDFix from [here.](https://github.com/Lyall/MGSHDFix/releases)
 - Extract the contents of the release zip in to the the game folder.<br />(e.g. "**steamapps\common\MGS2**" or "**steamapps\common\MGS3**" for Steam).
 
-### Steam Deck/Linux additional instructions
-Steam Deck users can also enjoy a native 800p (16:10) experience by installing this mod.
-- Open up the Steam properties of either MGS2/MGS3 and put `WINEDLLOVERRIDES="wininet,winhttp=n,b" %command%` in the launch options.
+### Steam Deck/Linux Additional Instructions
+🚩**You do not need to do this if you are using Windows!**
+- Open up the game properties of either MGS2/MGS3 in Steam and add `WINEDLLOVERRIDES="wininet,winhttp=n,b" %command%` to the launch options.
 
 ## Configuration
 - See **MGSHDFix.ini** to adjust settings for the fix.

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -546,7 +546,6 @@ void CustomResolution()
                 if (MGS2_MGS3_FullscreenFramebufferFixScanResult)
                 {
                     spdlog::info("MG/MG2 | MGS 2 | MGS 3: Fullscreen Framebuffer {}: Address is {:s}+{:x}", i, sExeName.c_str(), (uintptr_t)MGS2_MGS3_FullscreenFramebufferFixScanResult - (uintptr_t)baseModule);
-
                     Memory::PatchBytes((uintptr_t)MGS2_MGS3_FullscreenFramebufferFixScanResult + 0x2, "\x90\x90\x90\x90", 4);
                     spdlog::info("MG/MG2 | MGS 2 | MGS 3: Fullscreen Framebuffer {}: Patched instruction.", i);
                 }
@@ -566,7 +565,6 @@ void CustomResolution()
                     Memory::PatchBytes((uintptr_t)MGS2_MGS3_WindowedFramebufferFixScanResult + 0x2A, "\xEB", 1);
                 if (eGameType == MgsGame::MGS2)
                     Memory::PatchBytes((uintptr_t)MGS2_MGS3_WindowedFramebufferFixScanResult + 0x27, "\xEB", 1);
-               
                 spdlog::info("MG/MG2 | MGS 2 | MGS 3: Windowed Framebuffer: Patched instructions.");
             }
             else if (!MGS2_MGS3_WindowedFramebufferFixScanResult)

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -825,7 +825,7 @@ void CompileGeometryShader()
     }
 
     if (iVectorLineScale < 1) {
-        iVectorLineScale = 512;
+        iVectorLineScale = 480;
     }
 
 


### PR DESCRIPTION
Adds a geometry shader to make line thickness scaling resolution-independent for MGS2/MGS3.

![i253](https://github.com/user-attachments/assets/9df4d66b-2aeb-494f-a8a5-8e13ded9ed20)

![imag235236e](https://github.com/user-attachments/assets/52fb90de-b072-4da2-afbb-4f40b9b73dc1)
