### PR TITLE
Adds config versioning system

### DIFF
--- a/MGSHDFix.ini
+++ b/MGSHDFix.ini
@@ -80,3 +80,7 @@ Enabled = false
 ; Converts FOV to vert- and matches 16:9 horizontal FOV.
 ; Only applies at <16:9. Will be disabled if aspect ratio is >1.778~.
 Enabled = true
+
+[Config Version]
+;Keep this at the bottom, please
+Version = 1

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -12,6 +12,8 @@ HMODULE unityPlayer;
 // Version
 string sFixName = "MGSHDFix";
 string sFixVer = "2.3.1";
+int iConfigVersion = 1; //increment this when making config changes, along with the number at the bottom of the config file
+                        //that way we can sanity check to ensure people don't have broken/disabled features due to old config files.
 
 // Logger
 std::shared_ptr<spdlog::logger> logger;
@@ -299,6 +301,18 @@ void ReadConfig()
     else {
         spdlog::info("Config file: {}", sExePath.string() + sConfigFile);
         ini.parse(iniFile);
+    }
+
+    int loadedConfigVersion;
+    inipp::get_value(ini.sections["Config Version"], "Version", loadedConfigVersion);
+    if (loadedConfigVersion != iConfigVersion) {
+        AllocConsole();
+        FILE* dummy;
+        freopen_s(&dummy, "CONOUT$", "w", stdout);
+        std::cout << "" << sFixName.c_str() << " v" << sFixVer.c_str() << " loaded." << std::endl;
+        std::cout << "MGSHDFix CONFIG ERROR: Outdated config file!" << std::endl;
+        std::cout << "MGSHDFix CONFIG ERROR: Please install -all- the files from the latest release!" << std::endl;
+        FreeLibraryAndExitThread(baseModule, 1);
     }
 
     // Grab desktop resolution


### PR DESCRIPTION
Just to make sure folks don't have features disabled from using an outdated config file that doesn't contain newly added options.

If they're using an outdate config file with missing options, a console window will pop up warning the user to fully update their files

![image](https://github.com/user-attachments/assets/8bdf4d63-2fb0-41f4-94bf-3fd426a6d620)


Usage; just increment both iConfigVersion (right below sFixVer) and the version number at the bottom of the config when adding new options.