### PR TITLE
Restructures release zip file to simplify support with mod managers

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -32,7 +32,16 @@ jobs:
     - run: C:\msys64\usr\bin\wget.exe -O .\UltimateASILoader_LICENSE.md https://raw.githubusercontent.com/ThirteenAG/Ultimate-ASI-Loader/master/license 
     - run: cp .\dinput8.dll .\wininet.dll
     - run: mv .\dinput8.dll .\winhttp.dll
-    - run: 7z a -tzip ${{ github.event.repository.name }}_${{ github.event.inputs.version }}.zip README.md ${{ github.event.repository.name }}.ini ${{ github.event.repository.name }}.asi wininet.dll winhttp.dll UltimateASILoader_LICENSE.md
+    - run: mkdir .\logs
+    - run: cp .\README.md .\logs\${{ github.event.repository.name }}.log
+    - run: mkdir .\plugins
+    - run: mv .\README.md .\plugins\${{ github.event.repository.name }}_README.md
+    - run: mv .\${{ github.event.repository.name }}.ini .\plugins\${{ github.event.repository.name }}.ini
+    - run: mv .\${{ github.event.repository.name }}.asi .\plugins\${{ github.event.repository.name }}.asi
+    - run: 7z a -tzip ${{ github.event.repository.name }}_${{ github.event.inputs.version }}.zip wininet.dll winhttp.dll UltimateASILoader_LICENSE.md
+    - run: 7z a ${{ github.event.repository.name }}_${{ github.event.inputs.version }}.zip plugins\
+    - run: 7z a ${{ github.event.repository.name }}_${{ github.event.inputs.version }}.zip logs\
+
     
     - uses: ncipollo/release-action@v1
       with:
@@ -43,3 +52,4 @@ jobs:
         draft: true
         generateReleaseNotes: true
         artifactErrorsFailBuild: true
+


### PR DESCRIPTION
Minor but important change! 

1. Creates a blank / dummy MGSHDFix.log file (a copy of the readme.md) in the \logs\ subdirectory so mod managers (such as vortex, the newly released [mgs mod manager](https://github.com/ANTIBigBoss/MGS-MC-Mod-Manager-and-Tool), and mod organizer 2) will cleanup the file properly when undeploying the mod - which is usually via a symlink system.

2. Moves the .asi and .ini files to the \plugins subdirectory to reduce the number of loose mod files in the main directory, since a number of other asi mods are coming out and the folder was getting full FAST