### PR TITLE
Potential fix for missing high resolution texture DLC steam bug

### DIFF
--- a/src/resources/steamworks_api.cpp
+++ b/src/resources/steamworks_api.cpp
@@ -9,6 +9,7 @@
 #include "isteamuser.h"
 #include "isteamuserstats.h"
 #include "isteaminput.h"
+#include "isteamapps.h"
 #include "version.h"
 
 #pragma warning(pop)
@@ -21,7 +22,34 @@ namespace
     SafetyHookMid SteamMidhook;
     SafetyHookMid SteamInputMidhook;
 
+    void FixMissingDLC()
+    {
+        if (!(eGameType & MGS3))
+        {
+            return;
+        }
+        spdlog::info("MGS3 DLC Fix: Checking for missing high resolution texture DLC...");
+        if (!SteamApps()->BIsSubscribedApp(2314282))
+        {
+            spdlog::info("MGS3 DLC Fix: High resolution texture DLC is missing, adding to library...");
+            SteamApps()->InstallDLC(2314282);
+            if (!SteamApps()->BIsSubscribedApp(2314282))
+            {
+                spdlog::error("MGS3 DLC Fix: Failed to add high resolution texture DLC to library.");
+                return;
+            }
+            SteamApps()->UninstallDLC(2314282);
+            spdlog::info("MGS3 DLC Fix: High resolution texture DLC is now added to steam library.");
+        }
+        else
+        {
+            spdlog::info("MGS3 DLC Fix: High resolution texture DLC is already in library.");
+        }
+
+    }
+
 }
+
 
 
 void SteamAPI::FetchAndCacheSteamID()
@@ -41,6 +69,7 @@ void SteamAPI::OnSteamInitialized()
     g_SteamAPI.bInitialized = true;
     ResetAllAchievements(); //DON'T FREAK OUT READING THIS. bResetAchievements needs to be true, and there's multiple user confirmations first.
                             //This must ALWAYS be called before StatPersistence to make sure we don't wipe out the user's persistence file if they cancel the reset.
+    FixMissingDLC();
     AfterSteamInitialized();
 }
 


### PR DESCRIPTION
Need someone who's having this issue to test this. 

It won't do anything if you DON'T have the issue - so don't bother testing it if you're able to download the DLC normally.

### Download: [MGSHDFix-run-484.zip](https://github.com/user-attachments/files/25366720/MGSHDFix-run-484.zip)

Steps:

1. Extract the zip into your game folder normally, overwriting any files
2. Launch the game -> start it up all the way until you see the title screen with Snake kicking the guard's ass with CQC
3. Close the game. 
4. Check if the DLC has showed up in your game's steam properties 
5. Go into your game's /logs directory
6. Post your `MGSHDFix_Game.log` file here


---------
Just for reference, it'll show up on this DLC tab:

<img width="1465" height="971" alt="image" src="https://github.com/user-attachments/assets/a37b3583-6cb8-44bd-9618-3a677543a962" />
