### PR TITLE
Reduce CPU Usage (Steam Deck performance fix)

### DIFF
--- a/MGSHDFix.vcxproj
+++ b/MGSHDFix.vcxproj
@@ -115,6 +115,7 @@
     <ClCompile Include="src\resources\gamevars.cpp" />
     <ClCompile Include="src\resources\helper.cpp" />
     <ClCompile Include="src\fixes\water_reflections.cpp" />
+    <ClCompile Include="src\fixes\busy_loop_fix.cpp" />
     <ClCompile Include="src\features\texture_buffer_size.cpp" />
     <ClCompile Include="src\resources\steamworks_api.cpp" />
     <ClCompile Include="src\features\stat_persistence.cpp" />
@@ -124,6 +125,7 @@
   <ItemGroup>
     <ClInclude Include="src\features\custom_resolution_and_borderless.hpp" />
     <ClInclude Include="src\features\mgs2_restore_dogtags.hpp" />
+    <ClInclude Include="src\fixes\busy_loop_fix.hpp" />
     <ClInclude Include="src\warnings\background_shuffle_warning.hpp" />
     <ClInclude Include="src\warnings\bugfix_mod_checks.hpp" />
     <ClInclude Include="src\features\settings_pesistence.hpp" />

--- a/MGSHDFix.vcxproj.filters
+++ b/MGSHDFix.vcxproj.filters
@@ -32,7 +32,7 @@
     <ClCompile Include="src\warnings\reshade_compatibility_checks.cpp">
       <Filter>Warnings</Filter>
     </ClCompile>
-    <ClCompile Include="src\fixes\water_reflections.cpp">
+    <ClCompile Include="src\fixes\busy_loop_fix.cpp">
       <Filter>Fixes</Filter>
     </ClCompile>
     <ClCompile Include="src\features\texture_buffer_size.cpp">
@@ -166,6 +166,9 @@
     </ClCompile>
     <ClCompile Include="src\features\custom_resolution_and_borderless.cpp">
       <Filter>Features</Filter>
+    </ClCompile>
+    <ClCompile Include="src\fixes\water_reflections.cpp">
+      <Filter>Fixes</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -324,6 +327,9 @@
     </ClInclude>
     <ClInclude Include="src\features\custom_resolution_and_borderless.hpp">
       <Filter>Features\Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="src\fixes\busy_loop_fix.hpp">
+      <Filter>Fixes\Headers</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -32,6 +32,7 @@
 #include "water_reflections.hpp"
 #include "mgs3_hud_fixes.hpp"
 #include "windows_fullscreen_optimization.hpp"
+#include "busy_loop_fix.hpp"
 
 //Warnings
 #include "asi_loader_checks.hpp"
@@ -466,6 +467,7 @@ static void InitializeSubsystems()
     INITIALIZE(FixAimingFullTilt::Initialize());
     INITIALIZE(MGS3HudFixes::Initialize());
     INITIALIZE(FixFullscreenOptimization::Fix());
+    INITIALIZE(g_BusyLoopFix.Initialize());
 
 #if !defined(RELEASE_BUILD) //todo category
     //todo: Make ultrawide reposition HUD elements correctly instead of stretching them
@@ -591,6 +593,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
     {
         spdlog::info("DLL_PROCESS_DETACH called, shutting down MGSHDFix.");
         g_StatPersistence.SaveStats();
+        g_BusyLoopFix.Shutdown();
         spdlog::shutdown();
     }
     return TRUE;

--- a/src/fixes/busy_loop_fix.cpp
+++ b/src/fixes/busy_loop_fix.cpp
@@ -1,0 +1,42 @@
+#include "stdafx.h"
+#include "common.hpp"
+#include "busy_loop_fix.hpp"
+#include "logging.hpp"
+
+static BusyLoopFix* g_instance = nullptr;
+
+BOOL WINAPI BusyLoopFix::PeekMessageW_Hook(LPMSG m, HWND h, UINT a, UINT b, UINT c)
+{
+    BOOL r = g_instance->m_hook.call<BOOL>(m, h, a, b, c);
+
+    if (!r)
+    {
+        MsgWaitForMultipleObjects(0, NULL, FALSE, 1, QS_ALLINPUT);
+    }
+
+    return r;
+}
+
+void BusyLoopFix::Initialize()
+{
+    if (!bEnabled)
+        return;
+
+    g_instance = this;
+
+    auto target = GetProcAddress(GetModuleHandleW(L"user32.dll"),"PeekMessageW");
+
+    if (!target)
+    {
+        spdlog::info("MGS 2 | MGS 3: BusyLoopFix - Failed to find PeekMessageW!");
+        return;
+    }
+
+    m_hook = safetyhook::create_inline(target, PeekMessageW_Hook);
+}
+
+void BusyLoopFix::Shutdown()
+{
+    m_hook = {};
+    g_instance = nullptr;
+}

--- a/src/fixes/busy_loop_fix.hpp
+++ b/src/fixes/busy_loop_fix.hpp
@@ -1,0 +1,16 @@
+
+#pragma once
+#include <safetyhook.hpp>
+
+class BusyLoopFix {
+public:
+    void Initialize();
+    void Shutdown();
+    static BOOL WINAPI PeekMessageW_Hook(LPMSG m, HWND h, UINT a, UINT b, UINT c);
+
+    bool bEnabled = false;
+private:
+    SafetyHookInline m_hook;
+};
+
+inline BusyLoopFix g_BusyLoopFix;

--- a/src/resources/config.cpp
+++ b/src/resources/config.cpp
@@ -31,6 +31,7 @@
 #include "mgs2_restore_dogtags.hpp"
 #include "windows_fullscreen_optimization.hpp"
 #include "custom_resolution_and_borderless.hpp"
+#include "busy_loop_fix.hpp"
 
 // -----------------------------------------------------------------------------
 // ConfigHelper: A type-safe, case-insensitive, error-checked INI config reader.
@@ -607,8 +608,13 @@ void Config::Read()
     ConfigHelper::getValue(ini, ConfigKeys::SaveFileReadOnlyWarning_Section, ConfigKeys::SaveFileReadOnlyWarning_Setting, CheckGamesaveFolderWritable::bCheckSaveFilesReadOnly);
     LOG_CONFIG(ConfigKeys::SaveFileReadOnlyWarning_Section, ConfigKeys::SaveFileReadOnlyWarning_Setting, CheckGamesaveFolderWritable::bCheckSaveFilesReadOnly);
 
-    
+    // Busy Loop Fix
+    if (eGameType & (MGS2 | MGS3))
+    {
+        ConfigHelper::getValue(ini, ConfigKeys::BusyLoopFix_Section, ConfigKeys::BusyLoopFix_Enabled, g_BusyLoopFix.bEnabled);
 
-        
+        LOG_CONFIG(ConfigKeys::BusyLoopFix_Section, ConfigKeys::BusyLoopFix_Enabled, g_BusyLoopFix.bEnabled);
+    }
+
     ConfigLogger::Flush();
 }

--- a/src/resources/config_keys.hpp
+++ b/src/resources/config_keys.hpp
@@ -208,7 +208,8 @@ namespace ConfigKeys
                                                                   "HKEY_CURRENT_USER\\Software\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\Layers\n"
                                                                   "\n"
                                                                   "Equivalent to: Right-click the game's .exe -> Properties -> Compatibility -> check \"Disable Fullscreen Optimizations\"";
-
+    constexpr const char* BusyLoopFix_Section = "Bugfixes";
+    constexpr const char* BusyLoopFix_Enabled = "Fix high CPU usage";
 
     // Gameplay
     constexpr const char* KeepAimingAfterFiring_Always_Section = "Keep Aiming After Firing";


### PR DESCRIPTION
Addresses: https://github.com/Lyall/MGSHDFix/issues/213

Konami decoupled window message handling from the game thread in 1.4, but it seems they forgot to wait when there are no messages in the queue, causing the thread to busy wait.

Even on my 12700k, one core was being nearly pinned at 80% to 100% usage. On weaker machines this manifested as increased power usage and lower performance.

Before:
<img width="977" height="80" alt="image" src="https://github.com/user-attachments/assets/4e633c3e-5a50-4325-bc4e-0768eb87c89f" />

<img width="127" height="120" alt="image" src="https://github.com/user-attachments/assets/ea535bb9-730a-4791-9d8d-a378c8e696aa" />

After:
<img width="982" height="74" alt="image" src="https://github.com/user-attachments/assets/c961427d-3353-40d3-adc5-e74efbc0885c" />

<img width="110" height="67" alt="image" src="https://github.com/user-attachments/assets/86bf8faf-0ed0-4959-bb62-2e780f4791c0" />


I was having trouble getting the config tool to compile, so a seperate PR may be needed to add this setting to it.