### PR TITLE
MGS2: restore helicopter gas haze smoke (smk_blur)

### DIFF
--- a/ConfigTool/tab_data.cpp
+++ b/ConfigTool/tab_data.cpp
@@ -257,6 +257,9 @@ std::nullopt, false, Field::Int, 100, 1, 100},
         { ConfigKeys::MGS2LensDroplets_Section, ConfigKeys::MGS2LensDroplets_Setting, ConfigKeys::MGS2LensDroplets_Help, ConfigKeys::MGS2LensDroplets_Tooltip,
           std::nullopt, false, Field::Bool, true },
 
+        { ConfigKeys::MGS2GasHaze_Section, ConfigKeys::MGS2GasHaze_Setting, ConfigKeys::MGS2GasHaze_Help, ConfigKeys::MGS2GasHaze_Tooltip,
+          std::nullopt, false, Field::Bool, true },
+
         { ConfigKeys::MGS2_Increase_Shadow_Resolution_Section, ConfigKeys::MGS2_Increase_Shadow_Resolution_Setting, ConfigKeys::MGS2_Increase_Shadow_Resolution_Help, ConfigKeys::MGS2_Increase_Shadow_Resolution_Tooltip,
           std::nullopt, false, Field::Bool, true },
 

--- a/MGSHDFix.vcxproj
+++ b/MGSHDFix.vcxproj
@@ -70,6 +70,7 @@
     <ClCompile Include="src\fixes\mgs2_scope_warp.cpp" />
     <ClCompile Include="src\fixes\mgs2_water_effects.cpp" />
     <ClCompile Include="src\fixes\mgs2_lens_droplets.cpp" />
+    <ClCompile Include="src\fixes\mgs2_gas_haze.cpp" />
     <ClCompile Include="src\features\keep_aiming_after_firing.cpp" />
     <ClCompile Include="src\features\mgs2_sunglasses.cpp" />
     <ClCompile Include="src\resources\config.cpp" />
@@ -148,6 +149,7 @@
     <ClCompile Include="src\fixes\pause_on_focus_loss.cpp" />
     <ClCompile Include="src\fixes\stereo_audio.cpp" />
     <ClCompile Include="src\resources\d3d11_api.cpp" />
+    <ClCompile Include="src\resources\scene_depth.cpp" />
     <ClCompile Include="src\resources\gamevars.cpp" />
     <ClCompile Include="src\resources\helper.cpp" />
     <ClCompile Include="src\fixes\water_reflections.cpp" />
@@ -216,6 +218,7 @@
     <ClInclude Include="src\fixes\mgs2_scope_warp.hpp" />
     <ClInclude Include="src\fixes\mgs2_water_effects.hpp" />
     <ClInclude Include="src\fixes\mgs2_lens_droplets.hpp" />
+    <ClInclude Include="src\fixes\mgs2_gas_haze.hpp" />
     <ClInclude Include="src\fixes\mgs2_autopacket.hpp" />
     <ClInclude Include="src\features\keep_aiming_after_firing.hpp" />
     <ClInclude Include="src\features\mgs2_sunglasses.hpp" />
@@ -244,6 +247,7 @@
     <ClInclude Include="src\fixes\pause_on_focus_loss.hpp" />
     <ClInclude Include="src\fixes\stereo_audio.hpp" />
     <ClInclude Include="src\resources\d3d11_api.hpp" />
+    <ClInclude Include="src\resources\scene_depth.hpp" />
     <ClInclude Include="src\resources\helper.hpp" />
     <ClInclude Include="src\warnings\reshade_compatibility_checks.hpp" />
     <ClInclude Include="src\resources\stdafx.h" />

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -37,6 +37,7 @@
 #include "mgs2_scope_warp.hpp"
 #include "mgs2_water_effects.hpp"
 #include "mgs2_lens_droplets.hpp"
+#include "mgs2_gas_haze.hpp"
 #include "cpu_core_limit.hpp"
 #include "aiming_after_equip.hpp"
 #include "line_scaling.hpp"
@@ -519,6 +520,7 @@ static void InitializeSubsystems()
         INITIALIZE(MGS2ScopeWarp::Initialize());
         INITIALIZE(MGS2WaterEffects::Initialize());
         INITIALIZE(MGS2LensDroplets::Initialize());
+        INITIALIZE(MGS2GasHaze::Initialize());
         INITIALIZE(CoolantMirrorFix::ApplyFix());
         INITIALIZE(ResolutionScalingFixes::ApplyFixes()); // Always load after custom resolution
         INITIALIZE(TextureLiveSwaps::ApplyFixes());

--- a/src/fixes/mgs2_gas_haze.cpp
+++ b/src/fixes/mgs2_gas_haze.cpp
@@ -1,0 +1,465 @@
+#include "stdafx.h"
+#include "common.hpp"
+#include "mgs2_gas_haze.hpp"
+
+#include "helper.hpp"
+#include "logging.hpp"
+#include "d3d11_api.hpp"
+#include "scene_depth.hpp"
+
+#include <cstdint>
+#include <vector>
+#include <mutex>
+
+namespace
+{
+    // NewSmokeBlurEffect (smk_blur.c) - the heli smoke. start_speed 0 -> x64 0/0 = NaN (PS2 clamped it)
+    // so nothing draws; we clamp it to 1.
+    constexpr const char* kSig =
+        "48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 41 56 41 57 48 83 EC ?? "
+        "8B 7C 24 ?? 41 8B E8 41 8B F1 44 8B F2 45 33 C9 4C 8B F9 BA 00 20 00 00 "
+        "44 8D 04 7F 41 C1 E0 04 41 81 C0 00 02 00 00 41 8D 49 0A";
+
+    // The Act sets vertex alpha = pos.vw * XMM7 (loaded once from a shared 64.0 constant); override XMM7
+    // right after the load to set opacity. Centre verts get alpha, rim verts stay 0 (soft puff).
+    constexpr const char* kAlphaSig         = "F3 0F 10 3D CC C6 18 00";
+    constexpr ptrdiff_t   kAlphaHookOffset  = 8;
+    constexpr float       kAlphaScale       = 120.0f;   // centre-vert alpha = pos.vw * this (byte-capped)
+    constexpr int         kAlphaFloor       = 0;        // keep 0 so rim verts stay transparent (soft edge)
+    constexpr float       kTintScale        = 1.5f;     // PS2 colour 0-128 -> MC 0-255; scale 0x81 grey up
+
+    constexpr const char* kDieSig =
+        "48 89 5C 24 08 57 48 83 EC 20 48 8B 59 60 48 8B F9 48 85 DB 74 10 48 8B CB";
+
+    // smk_blur Act - fills the prim2 vertices each frame; we read them.
+    constexpr const char* kActSig =
+        "4C 8B DC 49 89 5B 18 49 89 73 20 55 57 41 54 41 55 41 56 49 8D 6B 98 48 81 EC 40 01 00 00";
+    constexpr ptrdiff_t kWork_Clock    = 0x1c8;
+    constexpr ptrdiff_t kWork_PrimBase = 0x60;
+    constexpr ptrdiff_t kWork_NPrims   = 0x1e8;
+    constexpr ptrdiff_t kPrim_PosBuf   = 0xc0;    // FVECTOR* pos[] (world-space vertex positions)
+    constexpr ptrdiff_t kPrim_UvrgbBuf = 0xd0;
+    constexpr ptrdiff_t kPrim_FlagBuf  = 0x268;
+    constexpr ptrdiff_t kFlag_Stride   = 0x40;
+    constexpr ptrdiff_t kFlag_Off      = 0x1a;
+    constexpr uint16_t  kInvisible0    = 0x1000;
+    constexpr int       kNVerts        = 17;
+
+    constexpr ptrdiff_t kClockRva   = 0x15521BC;       // global DG_Clock, for frame-change detection
+    constexpr ptrdiff_t kEyePersRva = 0x15522A0;       // DG_Chanl(0)->eye_pers (view-projection, 16 floats)
+    constexpr float     kUv2Norm   = 1.0f / 4096.0f;
+    constexpr float     kWarp      = 0.98f;            // PS2 ADDRESS_SCALE magnify
+    constexpr float     kBlurOff   = 0.016f;           // PS blur kernel radius (normalised UV); wider = softer
+                                                        // puff edges (fades the per-polygon seams)
+    constexpr float     kDepthBias = 0.0002f;          // reversed-Z occlusion epsilon (tuned)
+
+    // smk_blur is a framebuffer-sampling prim2 that MC's D3D11 backend never draws, so we draw it
+    // ourselves: read the Act's puff geometry and render it in D3D11 (see DrawInto).
+    constexpr float kDrawW = 512.0f;   // smk_blur's virtual screen (UV * this = pixel)
+    constexpr float kDrawH = 448.0f;
+
+    SafetyHookInline g_hook{};
+    SafetyHookMid    g_alphaHook{};
+    SafetyHookInline g_actHook{};
+    SafetyHookInline g_dieHook{};
+
+    int g_lastClock   = -0x7fffffff;
+    int g_activeCount = 0;
+
+    struct GasVertex { float x, y, u, v, z; uint32_t color; };   // z = projected reversed-Z (occlusion)
+
+    std::mutex            g_vmtx;
+    std::vector<GasVertex> g_verts;       // this frame's smoke triangles (filled by Act, drawn end-of-3D)
+    float g_eyePers[16] = {};             // camera view-projection snapshot (read each frame)
+
+    // ---- D3D11 resources -------------------------------------------------------------------------
+    const char* kShader = R"(
+    Texture2D    sceneTex : register(t0);
+    Texture2D    depthTex : register(t1);
+    SamplerState sampLin  : register(s0);
+    SamplerState sampPt   : register(s1);
+    cbuffer CB : register(b0) {
+        float2 invDraw;      // 1/512, 1/448
+        float2 screenSize;   // backbuffer w,h
+        float  depthBias;
+        float  blurOff;
+        float2 _pad;
+    };
+    struct VSIn  { float2 pos:POSITION; float2 uv:TEXCOORD0; float z:TEXCOORD1; float4 col:COLOR0; };
+    struct VSOut { float4 pos:SV_Position; float2 uv:TEXCOORD0; float z:TEXCOORD1; float4 col:COLOR0; };
+    VSOut VS(VSIn i){
+        VSOut o;
+        float2 ndc = float2(i.pos.x*invDraw.x*2.0-1.0, 1.0 - i.pos.y*invDraw.y*2.0);
+        o.pos = float4(ndc, 0.0, 1.0); o.uv = i.uv; o.z = i.z; o.col = i.col; return o;
+    }
+    static const float2 K[16] = {
+        float2(1,0), float2(-1,0), float2(0,1), float2(0,-1),
+        float2(0.7,0.7), float2(-0.7,0.7), float2(0.7,-0.7), float2(-0.7,-0.7),
+        float2(0.45,0), float2(-0.45,0), float2(0,0.45), float2(0,-0.45),
+        float2(0.32,0.32), float2(-0.32,0.32), float2(0.32,-0.32), float2(-0.32,-0.32) };
+    float4 PS(VSOut i):SV_Target {
+        // Warp: sample the scene at the puff's displaced UV (~2% zoom), blurred over 16 taps.
+        float3 c = 0;
+        [unroll] for (int k=0;k<16;k++) c += sceneTex.Sample(sampLin, i.uv + K[k]*blurOff).rgb;
+        c /= 16.0;
+        // light-grey tint; keep low or it turns into a flat grey blob and loses the warp
+        const float  kGreyMix   = 0.12;
+        const float3 kSmokeGrey = float3(0.82, 0.82, 0.85);
+        c = lerp(c, kSmokeGrey, kGreyMix);
+        float2 sUV   = i.pos.xy / screenSize;
+        float  sceneZ = depthTex.Sample(sampPt, sUV).r;
+        // reversed-Z (far=0, nearer=larger): hide where scene geometry is nearer than this puff
+        if (sceneZ > i.z + depthBias) discard;
+        return float4(c, i.col.a);
+    }
+    )";
+
+    ComPtr<ID3D11VertexShader>      g_vs;
+    ComPtr<ID3D11PixelShader>       g_ps;
+    ComPtr<ID3D11InputLayout>       g_layout;
+    ComPtr<ID3D11Buffer>            g_cb;
+    ComPtr<ID3D11Buffer>            g_vb;
+    UINT                            g_vbCap = 0;
+    ComPtr<ID3D11BlendState>        g_blend;
+    ComPtr<ID3D11RasterizerState>   g_rs;
+    ComPtr<ID3D11DepthStencilState> g_dss;
+    ComPtr<ID3D11SamplerState>      g_sampLin, g_sampPt;
+    ComPtr<ID3D11Texture2D>         g_capTex;
+    ComPtr<ID3D11ShaderResourceView> g_capSRV;
+    UINT g_capW = 0, g_capH = 0;
+    bool g_d3dInit = false, g_d3dFailed = false;
+
+    // ---- read the prim and build CPU triangles ----------------------------------------------------
+    void AppendInstance(uintptr_t work)
+    {
+        int clock  = *reinterpret_cast<int*>(work + kWork_Clock);
+        int nprims = *reinterpret_cast<int*>(work + kWork_NPrims);
+        uintptr_t prim = *reinterpret_cast<uintptr_t*>(work + kWork_PrimBase + (ptrdiff_t)clock * 8);
+        if (!prim || nprims <= 0) return;
+        uintptr_t uvBuf   = *reinterpret_cast<uintptr_t*>(prim + kPrim_UvrgbBuf);
+        uintptr_t posBuf  = *reinterpret_cast<uintptr_t*>(prim + kPrim_PosBuf);
+        uintptr_t flagBuf = *reinterpret_cast<uintptr_t*>(prim + kPrim_FlagBuf);
+        if (!uvBuf) return;
+        const float* M = g_eyePers;
+
+        for (int j = 0; j < nprims; ++j)
+        {
+            if (flagBuf)
+            {
+                uint16_t f = *reinterpret_cast<uint16_t*>(flagBuf + kFlag_Off + (ptrdiff_t)j * kFlag_Stride);
+                if (f & kInvisible0) continue;
+            }
+            const uint8_t* vbase = reinterpret_cast<const uint8_t*>(uvBuf + (size_t)j * kNVerts * 0x10);
+
+            for (int i = 2; i < kNVerts; ++i)
+            {
+                uint16_t kf = *reinterpret_cast<const uint16_t*>(vbase + (size_t)i * 0x10 + 0xe);
+                if (kf & 0x8000) continue;                       // vertex-kick: no triangle
+
+                GasVertex tri[3];
+                bool offscreen = false;
+                for (int k = 0; k < 3; ++k)
+                {
+                    const uint8_t* uv = vbase + (size_t)(i - 2 + k) * 0x10;
+                    int ui = *reinterpret_cast<const int16_t*>(uv + 8);
+                    int vi = *reinterpret_cast<const int16_t*>(uv + 0xa);
+                    if (ui < 0 || ui > 4096 || vi < 0 || vi > 4096) { offscreen = true; break; }
+                    float un = ui * kUv2Norm;
+                    float vn = vi * kUv2Norm;
+                    int a = uv[6] + kAlphaFloor; if (a > 255) a = 255;
+                    int tr = (int)(uv[0] * kTintScale); if (tr > 255) tr = 255;
+                    int tg = (int)(uv[2] * kTintScale); if (tg > 255) tg = 255;
+                    int tb = (int)(uv[4] * kTintScale); if (tb > 255) tb = 255;
+                    tri[k].u = un;
+                    tri[k].v = vn;
+                    tri[k].x = (0.5f + (un - 0.5f) / kWarp) * kDrawW;   // polygon = un-magnified UV
+                    tri[k].y = (0.5f + (vn - 0.5f) / kWarp) * kDrawH;
+                    tri[k].color = uint32_t(tr) | (uint32_t(tg) << 8) | (uint32_t(tb) << 16) | (uint32_t(a) << 24);
+
+                    // Project this puff vertex's world position to the depth buffer's reversed-Z.
+                    tri[k].z = 0.0f;
+                    if (posBuf)
+                    {
+                        const float* wp = reinterpret_cast<const float*>(
+                            posBuf + (size_t)((j * kNVerts) + (i - 2 + k)) * 0x10);
+                        float wx = wp[0], wy = wp[1], wz = wp[2];
+                        // Column-major M*v -> GL clip Z [-1,1]; remap to the D3D reversed-Z buffer [0,1].
+                        float cz = wx*M[2] + wy*M[6] + wz*M[10] + M[14];
+                        float cw = wx*M[3] + wy*M[7] + wz*M[11] + M[15];
+                        if (cw != 0.0f) tri[k].z = (cz / cw + 1.0f) * 0.5f;
+                    }
+                }
+                if (offscreen) continue;
+
+                std::lock_guard<std::mutex> lk(g_vmtx);
+                for (int k = 0; k < 3; ++k) g_verts.push_back(tri[k]);
+            }
+        }
+    }
+
+    void BuildSmoke(uintptr_t work)
+    {
+        uintptr_t base = reinterpret_cast<uintptr_t>(baseModule);
+        int clock = *reinterpret_cast<int*>(base + kClockRva);
+        if (clock != g_lastClock)
+        {
+            g_lastClock = clock;
+            memcpy(g_eyePers, reinterpret_cast<const void*>(base + kEyePersRva), sizeof(g_eyePers));
+            std::lock_guard<std::mutex> lk(g_vmtx);
+            g_verts.clear();
+        }
+        AppendInstance(work);
+    }
+
+    void __fastcall Act_Detour(uintptr_t work)
+    {
+        g_actHook.fastcall<void>(work);
+        if (!work) return;
+        __try { BuildSmoke(work); }
+        __except (EXCEPTION_EXECUTE_HANDLER) {}
+    }
+
+    void* __fastcall NewSmokeBlur_Detour(uintptr_t world, int start_speed, int end_speed, int start_size,
+                                         int end_size, int spot_size, int spot_angle, int n_prims,
+                                         int interval, int color, int flag)
+    {
+        if (start_speed == 0) start_speed = 1;                   // avoid the 0/0 NaN
+        void* work = g_hook.fastcall<void*>(world, start_speed, end_speed, start_size, end_size, spot_size,
+                                            spot_angle, n_prims, interval, color, flag);
+        if (work) g_activeCount++;
+        return work;
+    }
+
+    void __fastcall Die_Detour(uintptr_t actor)
+    {
+        g_dieHook.fastcall<void>(actor);
+        if (--g_activeCount <= 0)
+        {
+            g_activeCount = 0;
+            std::lock_guard<std::mutex> lk(g_vmtx);
+            g_verts.clear();
+        }
+    }
+
+    bool EnsureD3D()
+    {
+        if (g_d3dInit) return true;
+        if (g_d3dFailed) return false;
+
+        ID3D11Device* dev = g_D3D11Hooks.d3dDevice.Get();
+        if (!dev) return false;
+
+        HMODULE comp = LoadLibraryA("d3dcompiler_43.dll");
+        if (!comp) { g_d3dFailed = true; spdlog::error("GasHaze: no d3dcompiler_43.dll"); return false; }
+        auto D3DCompileFn = reinterpret_cast<pD3DCompile>(GetProcAddress(comp, "D3DCompile"));
+
+        ComPtr<ID3DBlob> vsb, psb, err;
+        bool ok = D3DCompileFn && SUCCEEDED(D3DCompileFn(kShader, strlen(kShader), nullptr, nullptr, nullptr,
+                        "VS", "vs_5_0", 0, 0, vsb.GetAddressOf(), err.ReleaseAndGetAddressOf()));
+        if (ok) ok = SUCCEEDED(D3DCompileFn(kShader, strlen(kShader), nullptr, nullptr, nullptr,
+                        "PS", "ps_5_0", 0, 0, psb.GetAddressOf(), err.ReleaseAndGetAddressOf()));
+        if (!ok)
+        {
+            spdlog::error("GasHaze: shader compile failed: {}", err ? (const char*)err->GetBufferPointer() : "?");
+            FreeLibrary(comp); g_d3dFailed = true; return false;
+        }
+
+        dev->CreateVertexShader(vsb->GetBufferPointer(), vsb->GetBufferSize(), nullptr, g_vs.GetAddressOf());
+        dev->CreatePixelShader(psb->GetBufferPointer(), psb->GetBufferSize(), nullptr, g_ps.GetAddressOf());
+
+        D3D11_INPUT_ELEMENT_DESC il[] = {
+            { "POSITION", 0, DXGI_FORMAT_R32G32_FLOAT,   0, 0,  D3D11_INPUT_PER_VERTEX_DATA, 0 },
+            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT,   0, 8,  D3D11_INPUT_PER_VERTEX_DATA, 0 },
+            { "TEXCOORD", 1, DXGI_FORMAT_R32_FLOAT,      0, 16, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+            { "COLOR",    0, DXGI_FORMAT_R8G8B8A8_UNORM, 0, 20, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+        };
+        dev->CreateInputLayout(il, 4, vsb->GetBufferPointer(), vsb->GetBufferSize(), g_layout.GetAddressOf());
+
+        D3D11_BUFFER_DESC cbd = {}; cbd.ByteWidth = 32; cbd.Usage = D3D11_USAGE_DYNAMIC;
+        cbd.BindFlags = D3D11_BIND_CONSTANT_BUFFER; cbd.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+        dev->CreateBuffer(&cbd, nullptr, g_cb.GetAddressOf());
+
+        D3D11_BLEND_DESC bd = {}; auto& rt = bd.RenderTarget[0];
+        rt.BlendEnable = TRUE;
+        rt.SrcBlend = D3D11_BLEND_SRC_ALPHA;  rt.DestBlend = D3D11_BLEND_INV_SRC_ALPHA; rt.BlendOp = D3D11_BLEND_OP_ADD;
+        rt.SrcBlendAlpha = D3D11_BLEND_ZERO;  rt.DestBlendAlpha = D3D11_BLEND_ONE;       rt.BlendOpAlpha = D3D11_BLEND_OP_ADD;
+        rt.RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
+        dev->CreateBlendState(&bd, g_blend.GetAddressOf());
+
+        D3D11_RASTERIZER_DESC rd = {}; rd.FillMode = D3D11_FILL_SOLID; rd.CullMode = D3D11_CULL_NONE;
+        dev->CreateRasterizerState(&rd, g_rs.GetAddressOf());
+
+        D3D11_DEPTH_STENCIL_DESC dsd = {}; dsd.DepthEnable = FALSE; dsd.DepthWriteMask = D3D11_DEPTH_WRITE_MASK_ZERO;
+        dev->CreateDepthStencilState(&dsd, g_dss.GetAddressOf());
+
+        D3D11_SAMPLER_DESC sd = {}; sd.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+        sd.AddressU = sd.AddressV = sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP; sd.MaxLOD = D3D11_FLOAT32_MAX;
+        dev->CreateSamplerState(&sd, g_sampLin.GetAddressOf());
+        sd.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
+        dev->CreateSamplerState(&sd, g_sampPt.GetAddressOf());
+
+        FreeLibrary(comp);
+        g_d3dInit = true;
+        spdlog::info("GasHaze: D3D11 smoke pass initialised.");
+        return true;
+    }
+}
+
+void MGS2GasHaze::DrawInto(ID3D11RenderTargetView* sceneColor, ID3D11ShaderResourceView* depth)
+{
+    if (!(eGameType & MGS2) || !bEnabled || !sceneColor) return;
+    if (!EnsureD3D()) return;
+
+    // Snapshot this frame's geometry.
+    std::vector<GasVertex> verts;
+    {
+        std::lock_guard<std::mutex> lk(g_vmtx);
+        if (g_verts.empty()) return;
+        verts = g_verts;
+    }
+
+    auto* dev = g_D3D11Hooks.d3dDevice.Get();
+    auto* ctx = g_D3D11Hooks.d3dDeviceContext.Get();
+    if (!dev || !ctx) return;
+
+    // The scene colour RT (3D rendered, no UI yet) is both our draw target and the warp source.
+    ComPtr<ID3D11Resource> colorRes;
+    sceneColor->GetResource(colorRes.GetAddressOf());
+    ComPtr<ID3D11Texture2D> backbuf;
+    if (!colorRes || FAILED(colorRes.As(&backbuf)) || !backbuf) return;
+    D3D11_TEXTURE2D_DESC bb; backbuf->GetDesc(&bb);
+    if (bb.SampleDesc.Count != 1) return;   // MSAA scene RT not supported by the plain copy/SRV
+
+    // Capture the (clean - no smoke/UI) scene colour as the warp source.
+    if (!g_capTex || g_capW != bb.Width || g_capH != bb.Height)
+    {
+        g_capSRV.Reset(); g_capTex.Reset();
+        D3D11_TEXTURE2D_DESC td = bb;
+        td.BindFlags = D3D11_BIND_SHADER_RESOURCE; td.Usage = D3D11_USAGE_DEFAULT;
+        td.CPUAccessFlags = 0; td.MiscFlags = 0; td.SampleDesc = { 1, 0 };
+        if (FAILED(dev->CreateTexture2D(&td, nullptr, g_capTex.GetAddressOf()))) return;
+        D3D11_SHADER_RESOURCE_VIEW_DESC sv = {}; sv.Format = td.Format;
+        sv.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D; sv.Texture2D.MipLevels = 1;
+        dev->CreateShaderResourceView(g_capTex.Get(), &sv, g_capSRV.GetAddressOf());
+        g_capW = bb.Width; g_capH = bb.Height;
+    }
+    ctx->CopyResource(g_capTex.Get(), backbuf.Get());
+
+    // Grow the dynamic vertex buffer if needed.
+    UINT need = (UINT)verts.size();
+    if (!g_vb || g_vbCap < need)
+    {
+        g_vb.Reset();
+        g_vbCap = need + 512;
+        D3D11_BUFFER_DESC vd = {}; vd.ByteWidth = g_vbCap * sizeof(GasVertex);
+        vd.Usage = D3D11_USAGE_DYNAMIC; vd.BindFlags = D3D11_BIND_VERTEX_BUFFER;
+        vd.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+        if (FAILED(dev->CreateBuffer(&vd, nullptr, g_vb.GetAddressOf()))) { g_vbCap = 0; return; }
+    }
+    {
+        D3D11_MAPPED_SUBRESOURCE m;
+        if (FAILED(ctx->Map(g_vb.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &m))) return;
+        memcpy(m.pData, verts.data(), need * sizeof(GasVertex));
+        ctx->Unmap(g_vb.Get(), 0);
+    }
+    {
+        D3D11_MAPPED_SUBRESOURCE m;
+        ctx->Map(g_cb.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &m);
+        float cb[8] = { 1.0f / kDrawW, 1.0f / kDrawH, (float)bb.Width, (float)bb.Height,
+                        kDepthBias, kBlurOff, 0.0f, 0.0f };
+        memcpy(m.pData, cb, sizeof(cb));
+        ctx->Unmap(g_cb.Get(), 0);
+    }
+
+    D3D11_VIEWPORT vp = { 0, 0, (float)bb.Width, (float)bb.Height, 0.f, 1.f };
+    ID3D11ShaderResourceView* depthSRV = depth;   // null -> shader sees 0 -> no occlusion
+
+    // Save state.
+    ID3D11RenderTargetView* oRTV[8] = {}; ID3D11DepthStencilView* oDSV = nullptr;
+    ID3D11BlendState* oBlend = nullptr; FLOAT oBF[4]; UINT oBM = 0;
+    ID3D11DepthStencilState* oDSS = nullptr; UINT oSR = 0;
+    ID3D11RasterizerState* oRS = nullptr; ID3D11VertexShader* oVS = nullptr; ID3D11PixelShader* oPS = nullptr;
+    ID3D11InputLayout* oIL = nullptr; ID3D11Buffer* oVB = nullptr; UINT oStr = 0, oOff = 0;
+    ID3D11Buffer* oCB = nullptr; ID3D11ShaderResourceView* oSRV[2] = {}; ID3D11SamplerState* oSamp[2] = {};
+    ID3D11Buffer* oVCB = nullptr;
+    D3D11_PRIMITIVE_TOPOLOGY oTopo; D3D11_VIEWPORT oVP[1] = {}; UINT oNVP = 1;
+    ctx->OMGetRenderTargets(8, oRTV, &oDSV);
+    ctx->VSGetConstantBuffers(0, 1, &oVCB);
+    ctx->OMGetBlendState(&oBlend, oBF, &oBM);
+    ctx->OMGetDepthStencilState(&oDSS, &oSR);
+    ctx->RSGetState(&oRS); ctx->RSGetViewports(&oNVP, oVP);
+    ctx->VSGetShader(&oVS, nullptr, nullptr); ctx->PSGetShader(&oPS, nullptr, nullptr);
+    ctx->IAGetInputLayout(&oIL); ctx->IAGetVertexBuffers(0, 1, &oVB, &oStr, &oOff);
+    ctx->IAGetPrimitiveTopology(&oTopo);
+    ctx->PSGetConstantBuffers(0, 1, &oCB); ctx->PSGetShaderResources(0, 2, oSRV); ctx->PSGetSamplers(0, 2, oSamp);
+
+    // Draw.
+    UINT stride = sizeof(GasVertex), offset = 0;
+    ID3D11ShaderResourceView* srvs[2] = { g_capSRV.Get(), depthSRV };
+    ID3D11SamplerState* samps[2] = { g_sampLin.Get(), g_sampPt.Get() };
+    ctx->IASetInputLayout(g_layout.Get());
+    ctx->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    ctx->IASetVertexBuffers(0, 1, g_vb.GetAddressOf(), &stride, &offset);
+    ctx->VSSetShader(g_vs.Get(), nullptr, 0);
+    ctx->VSSetConstantBuffers(0, 1, g_cb.GetAddressOf());
+    ctx->PSSetShader(g_ps.Get(), nullptr, 0);
+    ctx->PSSetConstantBuffers(0, 1, g_cb.GetAddressOf());
+    ctx->PSSetShaderResources(0, 2, srvs);
+    ctx->PSSetSamplers(0, 2, samps);
+    ctx->OMSetBlendState(g_blend.Get(), nullptr, 0xFFFFFFFF);
+    ctx->OMSetDepthStencilState(g_dss.Get(), 0);
+    ctx->RSSetState(g_rs.Get());
+    ctx->RSSetViewports(1, &vp);
+    ctx->OMSetRenderTargets(1, &sceneColor, nullptr);
+    ctx->Draw(need, 0);
+
+    // Restore.
+    ctx->OMSetRenderTargets(8, oRTV, oDSV);
+    ctx->OMSetBlendState(oBlend, oBF, oBM);
+    ctx->OMSetDepthStencilState(oDSS, oSR);
+    ctx->RSSetState(oRS); ctx->RSSetViewports(oNVP, oVP);
+    ctx->VSSetShader(oVS, nullptr, 0); ctx->PSSetShader(oPS, nullptr, 0);
+    ctx->VSSetConstantBuffers(0, 1, &oVCB);
+    ctx->IASetInputLayout(oIL); ctx->IASetVertexBuffers(0, 1, &oVB, &oStr, &oOff);
+    ctx->IASetPrimitiveTopology(oTopo);
+    ctx->PSSetConstantBuffers(0, 1, &oCB); ctx->PSSetShaderResources(0, 2, oSRV); ctx->PSSetSamplers(0, 2, oSamp);
+    for (auto* r : oRTV) if (r) r->Release();
+    if (oDSV) oDSV->Release(); if (oBlend) oBlend->Release(); if (oDSS) oDSS->Release();
+    if (oRS) oRS->Release(); if (oVS) oVS->Release(); if (oPS) oPS->Release(); if (oIL) oIL->Release();
+    if (oVB) oVB->Release(); if (oCB) oCB->Release(); if (oVCB) oVCB->Release();
+    for (auto* s : oSRV) if (s) s->Release();
+    for (auto* s : oSamp) if (s) s->Release();
+}
+
+void MGS2GasHaze::Initialize()
+{
+    if (!(eGameType & MGS2) || !bEnabled) return;
+
+    if (uint8_t* address = Memory::PatternScan(baseModule, kSig, "MGS 2: Gas Haze - NewSmokeBlurEffect"))
+    {
+        g_hook = safetyhook::create_inline(address, reinterpret_cast<void*>(NewSmokeBlur_Detour));
+        LOG_HOOK(g_hook, "MGS 2: Gas Haze - NewSmokeBlurEffect");
+    }
+
+    if (uint8_t* alpha = Memory::PatternScan(baseModule, kAlphaSig, "MGS 2: Gas Haze - Alpha"))
+    {
+        g_alphaHook = safetyhook::create_mid(alpha + kAlphaHookOffset,
+            [](SafetyHookContext& ctx) { ctx.xmm7.f32[0] = kAlphaScale; });
+        LOG_HOOK(g_alphaHook, "MGS 2: Gas Haze - Alpha");
+    }
+
+    if (uint8_t* act = Memory::PatternScan(baseModule, kActSig, "MGS 2: Gas Haze - Act"))
+    {
+        g_actHook = safetyhook::create_inline(act, reinterpret_cast<void*>(Act_Detour));
+        LOG_HOOK(g_actHook, "MGS 2: Gas Haze - Act");
+    }
+
+    if (uint8_t* die = Memory::PatternScan(baseModule, kDieSig, "MGS 2: Gas Haze - Die"))
+    {
+        g_dieHook = safetyhook::create_inline(die, reinterpret_cast<void*>(Die_Detour));
+        LOG_HOOK(g_dieHook, "MGS 2: Gas Haze - Die");
+    }
+
+    // Draw the smoke at the end of the 3D pass (before UI/titles/credits) instead of at Present.
+    SceneDepth::SetEndOf3DCallback(&MGS2GasHaze::DrawInto);
+}

--- a/src/fixes/mgs2_gas_haze.hpp
+++ b/src/fixes/mgs2_gas_haze.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+struct ID3D11RenderTargetView;
+struct ID3D11ShaderResourceView;
+
+namespace MGS2GasHaze
+{
+    void Initialize();
+    // D3D11 smoke pass; called at the end of the 3D pass (before UI) via SceneDepth's callback,
+    // drawing into the scene colour RT with the live depth for occlusion.
+    void DrawInto(ID3D11RenderTargetView* sceneColor, ID3D11ShaderResourceView* depth);
+
+    inline bool bEnabled = true;
+};

--- a/src/resources/config.cpp
+++ b/src/resources/config.cpp
@@ -11,6 +11,7 @@
 #include "mgs2_scope_warp.hpp"
 #include "mgs2_water_effects.hpp"
 #include "mgs2_lens_droplets.hpp"
+#include "mgs2_gas_haze.hpp"
 #include "input_handler.hpp"
 #include "intro_skip.hpp"
 #include "line_scaling.hpp"
@@ -551,12 +552,14 @@ void Config::Read()
     ConfigHelper::getValue(ini, ConfigKeys::MGS2ScopeWarp_Section, ConfigKeys::MGS2ScopeWarp_Setting, MGS2ScopeWarp::bEnabled);
     ConfigHelper::getValue(ini, ConfigKeys::MGS2WaterEffects_Section, ConfigKeys::MGS2WaterEffects_Setting, MGS2WaterEffects::bEnabled);
     ConfigHelper::getValue(ini, ConfigKeys::MGS2LensDroplets_Section, ConfigKeys::MGS2LensDroplets_Setting, MGS2LensDroplets::bEnabled);
+    ConfigHelper::getValue(ini, ConfigKeys::MGS2GasHaze_Section, ConfigKeys::MGS2GasHaze_Setting, MGS2GasHaze::bEnabled);
     LOG_CONFIG(ConfigKeys::FixAimingAfterEquip_Section, ConfigKeys::FixAimingAfterEquip_Setting, g_FixAimAfterEquip.bEnabled);
     LOG_CONFIG(ConfigKeys::FixAimingFullTilt_Section, ConfigKeys::FixAimingFullTilt_Setting, FixAimingFullTilt::bEnabled);
     LOG_CONFIG(ConfigKeys::MGS2BloodStains_Section, ConfigKeys::MGS2BloodStains_Setting, MGS2BloodStains::bEnabled);
     LOG_CONFIG(ConfigKeys::MGS2ScopeWarp_Section, ConfigKeys::MGS2ScopeWarp_Setting, MGS2ScopeWarp::bEnabled);
     LOG_CONFIG(ConfigKeys::MGS2WaterEffects_Section, ConfigKeys::MGS2WaterEffects_Setting, MGS2WaterEffects::bEnabled);
     LOG_CONFIG(ConfigKeys::MGS2LensDroplets_Section, ConfigKeys::MGS2LensDroplets_Setting, MGS2LensDroplets::bEnabled);
+    LOG_CONFIG(ConfigKeys::MGS2GasHaze_Section, ConfigKeys::MGS2GasHaze_Setting, MGS2GasHaze::bEnabled);
 
     std::string sShouldWearSunglasses;
     ConfigHelper::getValue(ini, ConfigKeys::MGS2Sunglasses_Section, ConfigKeys::MGS2Sunglasses_Setting, sShouldWearSunglasses);

--- a/src/resources/config_keys.hpp
+++ b/src/resources/config_keys.hpp
@@ -353,6 +353,11 @@ namespace ConfigKeys
     constexpr const char* MGS2LensDroplets_Help = "";
     constexpr const char* MGS2LensDroplets_Tooltip = "Restores the refracting water droplets on the camera lens when surfacing, which are built but never drawn in the Master Collection.";
 
+    constexpr const char* MGS2GasHaze_Section = "Bugfixes";
+    constexpr const char* MGS2GasHaze_Setting = "MGS2 - Restore Gas Haze";
+    constexpr const char* MGS2GasHaze_Help = "";
+    constexpr const char* MGS2GasHaze_Tooltip = "Restores the smoke-shaped heat-haze distortion (e.g. the helicopter exhaust gas in the Plant intro), which is NaN'd out and invisible in the Master Collection.";
+
     constexpr const char* CPUCoreLimit_Section = "System Specific Fixes";
     constexpr const char* CPUCoreLimit_Setting = "Limit Game to 2 CPU Cores";
     constexpr const char* CPUCoreLimit_Help = "(Fixes cutscene crashes on some newer CPUs)";

--- a/src/resources/d3d11_api.cpp
+++ b/src/resources/d3d11_api.cpp
@@ -20,6 +20,8 @@
 #include "mgs2_thermal_goggles.hpp"
 #include "mgs2_underwater_filter.hpp"
 #include "d3d11_text_overlay.hpp"
+#include "scene_depth.hpp"
+#include "mgs2_gas_haze.hpp"
 void afterPresent();
 
 namespace
@@ -146,6 +148,7 @@ namespace
                 }
                 dxgiDevice->Release();
             }
+            SceneDepth::Initialize();   // hook OMSetRenderTargets now that the context exists
             afterPresent();
         }
 
@@ -165,6 +168,8 @@ namespace
 
         g_EffectSpeedFix.Tick();
         g_InputHandler.Update();
+
+        SceneDepth::CaptureForFrame();   // snapshot this frame's scene depth for effects to sample
 
         if (eGameType & MGS2)
         {

--- a/src/resources/scene_depth.cpp
+++ b/src/resources/scene_depth.cpp
@@ -1,0 +1,155 @@
+#include "stdafx.h"
+#include "scene_depth.hpp"
+
+#include "common.hpp"
+#include "d3d11_api.hpp"
+#include "logging.hpp"
+
+using Microsoft::WRL::ComPtr;
+
+namespace
+{
+    SafetyHookInline g_omSetRTHook{};
+
+    ComPtr<ID3D11Texture2D>          g_copyTex;
+    ComPtr<ID3D11ShaderResourceView> g_copySRV;
+    UINT g_copyW = 0, g_copyH = 0;
+    DXGI_FORMAT g_copyFmt = DXGI_FORMAT_UNKNOWN;
+    bool g_available = false;
+
+    // 3D-pass tracking, for the end-of-3D transition (draw effects under the UI).
+    ComPtr<ID3D11Texture2D>          g_sceneDepth;     // the scene depth currently bound
+    ComPtr<ID3D11RenderTargetView>   g_sceneColorRTV;  // colour RT bound alongside it
+    bool g_in3D  = false;
+    bool g_fired = false;
+    UINT g_bbArea = 0;
+
+    SceneDepth::EndOf3DCallback g_callback = nullptr;
+
+    bool MapDepthFormat(DXGI_FORMAT texFmt, DXGI_FORMAT& typeless, DXGI_FORMAT& srv)
+    {
+        switch (texFmt)
+        {
+        case DXGI_FORMAT_D24_UNORM_S8_UINT:
+        case DXGI_FORMAT_R24G8_TYPELESS:
+        case DXGI_FORMAT_R24_UNORM_X8_TYPELESS:
+            typeless = DXGI_FORMAT_R24G8_TYPELESS;       srv = DXGI_FORMAT_R24_UNORM_X8_TYPELESS;   return true;
+        case DXGI_FORMAT_D32_FLOAT:
+        case DXGI_FORMAT_R32_TYPELESS:
+            typeless = DXGI_FORMAT_R32_TYPELESS;         srv = DXGI_FORMAT_R32_FLOAT;               return true;
+        case DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
+        case DXGI_FORMAT_R32G8X24_TYPELESS:
+            typeless = DXGI_FORMAT_R32G8X24_TYPELESS;    srv = DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS; return true;
+        case DXGI_FORMAT_D16_UNORM:
+        case DXGI_FORMAT_R16_TYPELESS:
+            typeless = DXGI_FORMAT_R16_TYPELESS;         srv = DXGI_FORMAT_R16_UNORM;               return true;
+        default:
+            return false;
+        }
+    }
+
+    UINT BackbufferArea()
+    {
+        if (g_bbArea) return g_bbArea;
+        auto* sc = g_D3D11Hooks.swapChain.Get();
+        if (!sc) return 0;
+        DXGI_SWAP_CHAIN_DESC d{};
+        if (SUCCEEDED(sc->GetDesc(&d))) g_bbArea = d.BufferDesc.Width * d.BufferDesc.Height;
+        return g_bbArea;
+    }
+
+    // Copy a DSV texture into our shader-readable depth copy (CopyResource within the same typeless family).
+    void CopyDepth(ID3D11Texture2D* src)
+    {
+        if (!src) return;
+        auto* dev = g_D3D11Hooks.d3dDevice.Get();
+        auto* ctx = g_D3D11Hooks.d3dDeviceContext.Get();
+        if (!dev || !ctx) return;
+
+        D3D11_TEXTURE2D_DESC sd{};
+        src->GetDesc(&sd);
+        DXGI_FORMAT typeless, srvFmt;
+        if (!MapDepthFormat(sd.Format, typeless, srvFmt)) return;
+
+        if (!g_copyTex || g_copyW != sd.Width || g_copyH != sd.Height || g_copyFmt != typeless)
+        {
+            g_copySRV.Reset(); g_copyTex.Reset();
+            D3D11_TEXTURE2D_DESC td = sd;
+            td.Format = typeless; td.Usage = D3D11_USAGE_DEFAULT;
+            td.BindFlags = D3D11_BIND_SHADER_RESOURCE; td.CPUAccessFlags = 0; td.MiscFlags = 0;
+            if (FAILED(dev->CreateTexture2D(&td, nullptr, g_copyTex.GetAddressOf()))) return;
+            D3D11_SHADER_RESOURCE_VIEW_DESC srvd{};
+            srvd.Format = srvFmt; srvd.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D; srvd.Texture2D.MipLevels = 1;
+            if (FAILED(dev->CreateShaderResourceView(g_copyTex.Get(), &srvd, g_copySRV.GetAddressOf())))
+            { g_copyTex.Reset(); return; }
+            g_copyW = sd.Width; g_copyH = sd.Height; g_copyFmt = typeless;
+            spdlog::info("SceneDepth: depth copy target {}x{} fmt={}", sd.Width, sd.Height, (int)typeless);
+        }
+        ctx->CopyResource(g_copyTex.Get(), src);
+        g_available = true;
+    }
+
+    void STDMETHODCALLTYPE HookedOMSetRenderTargets(
+        ID3D11DeviceContext* ctx, UINT numViews,
+        ID3D11RenderTargetView* const* rtvs, ID3D11DepthStencilView* dsv)
+    {
+        bool sceneDepthBound = false;
+        if (dsv)
+        {
+            ComPtr<ID3D11Resource> res;
+            dsv->GetResource(res.GetAddressOf());
+            ComPtr<ID3D11Texture2D> tex;
+            if (res && SUCCEEDED(res.As(&tex)) && tex)
+            {
+                D3D11_TEXTURE2D_DESC d{};
+                tex->GetDesc(&d);
+                DXGI_FORMAT a, b;
+                UINT bb = BackbufferArea();
+                if (d.SampleDesc.Count == 1 && MapDepthFormat(d.Format, a, b) &&
+                    bb && (uint64_t)d.Width * d.Height >= (uint64_t)(bb * 0.6f))
+                {
+                    sceneDepthBound = true;
+                    g_sceneDepth = tex;
+                    if (numViews > 0 && rtvs && rtvs[0]) g_sceneColorRTV = rtvs[0];
+                }
+            }
+        }
+
+        if (sceneDepthBound)
+        {
+            g_in3D = true;
+        }
+        else if (g_in3D && !g_fired)   // first transition out of the 3D pass this frame
+        {
+            g_fired = true;
+            g_in3D = false;
+            CopyDepth(g_sceneDepth.Get());
+            if (g_callback && g_sceneColorRTV) g_callback(g_sceneColorRTV.Get(), g_available ? g_copySRV.Get() : nullptr);
+        }
+
+        g_omSetRTHook.stdcall<void>(ctx, numViews, rtvs, dsv);
+    }
+}
+
+void SceneDepth::Initialize()
+{
+    if (g_omSetRTHook) return;
+    ID3D11DeviceContext* ctx = g_D3D11Hooks.d3dDeviceContext.Get();
+    if (!ctx) { spdlog::error("SceneDepth: no device context to hook."); return; }
+    void** vtable = *reinterpret_cast<void***>(ctx);
+    g_omSetRTHook = safetyhook::create_inline(vtable[33], reinterpret_cast<void*>(HookedOMSetRenderTargets));
+    LOG_HOOK(g_omSetRTHook, "SceneDepth: OMSetRenderTargets");
+}
+
+void SceneDepth::CaptureForFrame()
+{
+    // Reset per-frame transition state (the depth copy + callback happen mid-frame at the 3D->UI edge).
+    g_fired = false;
+    g_in3D = false;
+    g_sceneColorRTV.Reset();
+    g_sceneDepth.Reset();
+}
+
+void SceneDepth::SetEndOf3DCallback(EndOf3DCallback cb) { g_callback = cb; }
+ID3D11ShaderResourceView* SceneDepth::GetSRV() { return g_available ? g_copySRV.Get() : nullptr; }
+bool SceneDepth::IsAvailable() { return g_available; }

--- a/src/resources/scene_depth.hpp
+++ b/src/resources/scene_depth.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <d3d11.h>
+#include <wrl/client.h>
+
+// Shared read access to the scene depth buffer, for fixes that need scene distance (occlusion, soft
+// particles, depth fog). The game's depth is DSV-only (not shader-readable), so we copy whatever depth
+// it binds for the 3D pass into a sampleable texture - the game's own resources are left untouched.
+//
+// Two uses:
+//   - GetSRV(): sample the depth in your shader. Raw 0..1, reversed-Z (far ~0, near ~1). May be null.
+//   - SetEndOf3DCallback(cb): to draw under the UI. cb fires after the 3D pass with the scene colour
+//     RT and depth SRV (this is how the smk_blur smoke draws + gets occluded).
+//
+// Initialize() once the device exists; CaptureForFrame() once per frame from Present.
+namespace SceneDepth
+{
+    void Initialize();
+    void CaptureForFrame();
+    ID3D11ShaderResourceView* GetSRV();
+    bool IsAvailable();
+
+    // Fires at the end of the 3D pass (after the scene, before UI). Gives the scene colour RT to draw
+    // into and the depth SRV for occlusion.
+    using EndOf3DCallback = void(*)(ID3D11RenderTargetView* sceneColor, ID3D11ShaderResourceView* depth);
+    void SetEndOf3DCallback(EndOf3DCallback cb);
+}


### PR DESCRIPTION
This is "gas" instead of "exhaust" as it isn't always used for exhaust (underwater 'suction' effect when raiden inflitrates).
This is a reconstruction, so tuning is required to taste, but it really gives a basis for general dx11 reconstruction of fx. 