### PR TITLE
Restore Fortune railgun effects and fix untextured prim brightness

### DIFF
--- a/MGSHDFix.vcxproj
+++ b/MGSHDFix.vcxproj
@@ -69,6 +69,7 @@
     <ClCompile Include="src\fixes\mgs2_gas_haze.cpp" />
     <ClCompile Include="src\fixes\mgs2_flare_occlusion.cpp" />
     <ClCompile Include="src\fixes\mgs2_demo_blur.cpp" />
+    <ClCompile Include="src\fixes\mgs2_railgun_beam.cpp" />
     <ClCompile Include="src\features\keep_aiming_after_firing.cpp" />
     <ClCompile Include="src\features\mgs2_sunglasses.cpp" />
     <ClCompile Include="src\resources\config.cpp" />
@@ -200,6 +201,7 @@
     <ClInclude Include="src\fixes\mgs2_gas_haze.hpp" />
     <ClInclude Include="src\fixes\mgs2_flare_occlusion.hpp" />
     <ClInclude Include="src\fixes\mgs2_demo_blur.hpp" />
+    <ClInclude Include="src\fixes\mgs2_railgun_beam.hpp" />
     <ClInclude Include="src\fixes\mgs2_autopacket.hpp" />
     <ClInclude Include="src\features\keep_aiming_after_firing.hpp" />
     <ClInclude Include="src\features\mgs2_sunglasses.hpp" />

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -40,6 +40,7 @@
 #include "mgs2_lens_droplets.hpp"
 #include "mgs2_gas_haze.hpp"
 #include "mgs2_flare_occlusion.hpp"
+#include "mgs2_railgun_beam.hpp"
 #include "mgs2_demo_blur.hpp"
 #include "cpu_core_limit.hpp"
 #include "aiming_after_equip.hpp"
@@ -549,6 +550,7 @@ static void InitializeSubsystems()
         INITIALIZE(MGS2LensDroplets::Initialize());
         INITIALIZE(MGS2GasHaze::Initialize());
         INITIALIZE(MGS2FlareOcclusion::Initialize());
+        INITIALIZE(MGS2RailgunBeam::InitializeEarly());
         INITIALIZE(MGS2DemoBlur::Initialize());
         INITIALIZE(CoolantMirrorFix::ApplyFix());
         INITIALIZE(ResolutionScalingFixes::ApplyFixes()); // Always load after custom resolution

--- a/src/fixes/effect_speeds.cpp
+++ b/src/fixes/effect_speeds.cpp
@@ -1,5 +1,8 @@
 // ReSharper disable CppClangTidyModernizeRawStringLiteral
 #include "stdafx.h"
+#include <intrin.h>
+#include "mgs2_railgun_beam.hpp"
+#include <unordered_map>
 
 #include "common.hpp"
 
@@ -10,27 +13,25 @@
 
 #include <cmath>
 
-
 /////////////////////////////////////////////////////////////////
 /// Corrects various visual effects in MGS2 which were
 /// hardcoded for the PS2's cutscene physics speed (30 FPS)
 /// and run at 2x with the HDC/MC's 60 FPS cutscene physics speed
-/// 
+///
 /// SolidusFireAct fix originally made as
 /// part of a modding fix bounty claimed by Cipherxof/Triggerhappy
 /// and originally included in the MGSFPSUnlock mod.
-/// They have been updated to fix several bugs, and upgraded (where needed) 
+/// They have been updated to fix several bugs, and upgraded (where needed)
 /// to use RTC timesteps for 1:1 PS2 accurate frame-timing.
-/// 
+///
 /////////////////////////////////////////////////////////////////
-
 
 #define MGS2_CUTSCENE_FRAMESKIP_TICK(name, isCutscene) \
     do                                            \
     {                                             \
         if ((isCutscene) && name##_first_hit)     \
         {                                         \
-            name##_skip = !name##_skip;           \
+            name##_skip = !name##_skip;       \
         }                                         \
     } while (false)
 
@@ -132,8 +133,156 @@
     X(NewSplushSurface2Man, "48 89 5C 24 ?? 48 89 74 24 ?? 48 89 4C 24", "MGS 2: Effect Speed Fix : user\\okajima\\effect2\\splush_surface_gravity_man.c -> NewSplushSurface2Man()") \
     X(NewTraffic_Flush, "48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 41 56 48 83 EC ?? 48 8B 51", "MGS 2: Effect Speed Fix : NewTraffic_Flush") \
     X(NewDebris_Tex, "40 57 48 83 EC ?? 48 89 5C 24 ?? 48 8B F9 48 89 6C 24", "MGS 2: Effect Speed Fix : user\\okajima\\effect2\\debris_tex.c -> NewDebris_Tex()") \
-    X(NewLinerGunPlasma, "48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC ?? 48 8B 99 ?? ?? ?? ?? 48 8B F1 8B 0D", "MGS 2: Effect Speed Fix : user\\okajima\\effect2\\liner_gun_plasma.c -> NewLinerGunPlasma() -> Act()") \
     X(NewFortSplineBulletDemo, NEW_FORT_SPLINE_BULLET_DEMO_PATTERN, "MGS 2: Effect Speed Fix : user\\morita\\demo_fort\\fort_b_line.c() -> Act()")
+
+// Same, but these also run during gameplay firing, so not gated to cutscenes.
+#define MGS2_RAILGUN_PLAYTIME_SKIPS_ALWAYS(X) \
+    X(RailgunTrailMed, "48 8B C4 48 89 58 10 48 89 70 18 57 41 54 41 55 41 56 41 57 48 81 EC F0", "MGS 2: Effect Speed Fix : Fortune railgun demo effect Act (med)") \
+    X(RailgunTrailA, "4C 8B DC 49 89 5B 10 49 89 7B 18 55 49 8D 6B A8 48 81 EC 50 01 00 00 48", "MGS 2: Effect Speed Fix : Fortune railgun trail Act A") \
+    X(RailgunTrailB, "48 89 5C 24 08 48 89 74 24 10 57 48 83 EC 30 8B 41 78 48 8B D9 44 8B 41", "MGS 2: Effect Speed Fix : Fortune railgun trail Act B")
+
+#define DEFINE_MGS2_PLAYTIME_ALWAYS_HOOK(name, pattern, label)      \
+    SafetyHookInline name##_hook {};                                \
+    static void name##_Hook(int64_t work)                           \
+    {                                                               \
+        if (MGS2_LinkVarBuf::linkvarbuf &&                          \
+            ((static_cast<int>(MGS2_LinkVarBuf::GM_StagePlayTime) & 1) == 0))   \
+        {                                                           \
+            return;                                                 \
+        }                                                           \
+        name##_hook.call(work);                                     \
+    }
+
+inline void HookRailgunVortexRate(HMODULE baseModule)
+{
+    // NewPlasmaEvade: reveal/fade are authored per 30fps frame and never tick-adjusted.
+    uint8_t* act = Memory::PatternScan(baseModule,
+        "48 89 5C 24 10 48 89 74 24 18 57 48 83 EC 30 48 8B F1 C7 44 24 40 00 00",
+        "MGS 2: Effect Speed Fix : NewPlasmaEvade Act");
+    if (!act) return;
+    // Single-buffered prims - correct the rates inside the update instead of skipping the Act.
+    if (memcmp(act + 0xF9, "\xF3\x0F\x11\x83\x24\x01\x00\x00", 8) != 0)
+    {
+        spdlog::error("MGS 2: Effect Speed Fix: plasma fade store no longer matches; skipping.");
+        return;
+    }
+    static SafetyHookMid plasmaFadeHook{};
+    plasmaFadeHook = safetyhook::create_mid(act + 0xF9,   // about to store fAlphaMax * 0.9
+        [](SafetyHookContext& ctx)
+        {
+            if (g_GameVars.InCutscene() && (*reinterpret_cast<const int32_t*>(ctx.rdi + 0x10) & 1))
+                ctx.xmm0.f32[0] *= 1.0f / 0.9f;   // net no-op this frame - fade at 30fps
+        });
+    LOG_HOOK(plasmaFadeHook, "MGS 2: Effect Speed Fix : NewPlasmaEvade 30fps fade")
+
+    uint8_t* drawing2 = Memory::PatternScan(baseModule,
+        "48 83 EC 40 8B 69 0C 33 F6 03 69 08 48 8B D9 48 8B 79",
+        "MGS 2: Effect Speed Fix : NewPlasmaEvade reveal step");
+    if (!drawing2) return;
+    static SafetyHookMid plasmaRevealHook{};
+    plasmaRevealHook = safetyhook::create_mid(drawing2 + 0xC,   // ebp = nDrawNum + nDrawSpd
+        [](SafetyHookContext& ctx)
+        {
+            if (g_GameVars.InCutscene() && (*reinterpret_cast<const int32_t*>(ctx.rcx + 0x10) & 1))
+                ctx.rbp -= *reinterpret_cast<const int32_t*>(ctx.rcx + 0xC);   // cancel this frame's step
+        });
+    LOG_HOOK(plasmaRevealHook, "MGS 2: Effect Speed Fix : NewPlasmaEvade 30fps reveal")
+
+    // The vortex ribbons draw per frame; hold only the life decrement.
+    uint8_t* vortexAct = Memory::PatternScan(baseModule,
+        "48 81 EC 88 00 00 00 83 3D ?? ?? ?? ?? 00 4C 8B C1 8B 89 70 01 00 00 44",
+        "MGS 2: Effect Speed Fix : Fortune railgun vortex ribbons Act");
+    if (!vortexAct) return;
+    if (memcmp(vortexAct + 0x3E, "\x41\x89\x80\x70\x01\x00\x00", 7) != 0)
+    {
+        spdlog::error("MGS 2: Effect Speed Fix: vortex ribbon life offset no longer matches; skipping.");
+        return;
+    }
+    static SafetyHookMid vortexLifeHook{};
+    vortexLifeHook = safetyhook::create_mid(vortexAct + 0x3E,   // about to store life-1
+        [](SafetyHookContext& ctx)
+        {
+            if (!g_GameVars.InCutscene()) return;
+            static std::unordered_map<uintptr_t, uint32_t> s_ticks;
+            if (s_ticks.size() > 64) s_ticks.clear();
+            // Native decay for the tail so the impact smoke dies before the camera cut.
+            if (static_cast<int32_t>(ctx.rcx & 0xFFFFFFFF) > 96 && (++s_ticks[ctx.r8] & 1) == 0)
+                ctx.rax = static_cast<uint32_t>(ctx.rcx);   // hold the decrement this frame
+        });
+    LOG_HOOK(vortexLifeHook, "MGS 2: Effect Speed Fix : vortex ribbon 30fps life")
+
+    // Swirl phase follows the life value, so extend the span instead of holding the decrement.
+    if (memcmp(vortexAct + 0xA99, "\xC7\x81\x70\x01\x00\x00\x78\x00\x00\x00", 10) == 0)
+    {
+        static SafetyHookMid vortexInitHook{};
+        vortexInitHook = safetyhook::create_mid(vortexAct + 0xAA3,   // right after: mov [rcx+0x170], 0x78
+            [](SafetyHookContext& ctx)
+            {
+                if (!g_GameVars.InCutscene())
+                    *reinterpret_cast<int32_t*>(ctx.rcx + 0x170) = 0xF0;
+            });
+        LOG_HOOK(vortexInitHook, "MGS 2: Effect Speed Fix : vortex ribbon gameplay life span")
+    }
+    else
+        spdlog::error("MGS 2: Effect Speed Fix: vortex ribbon life init no longer matches; skipping.");
+
+    // Ribbon alpha scale (48.0) - hooked at the load; the vertex loop below has a branch target.
+    if (memcmp(vortexAct + 0x7F0, "\x4C\x8D\x3D", 3) == 0)
+    {
+        static SafetyHookMid vortexAlphaHook{};
+        vortexAlphaHook = safetyhook::create_mid(vortexAct + 0x7F0,   // right after: movss xmm7, [rip] (=48.0)
+            [](SafetyHookContext& ctx)
+            {
+                ctx.xmm7.f32[0] *= g_GameVars.InCutscene() ? 0.5f : 0.125f;
+            });
+        LOG_HOOK(vortexAlphaHook, "MGS 2: Effect Speed Fix : vortex ribbon gameplay alpha")
+    }
+    else
+        spdlog::error("MGS 2: Effect Speed Fix: vortex ribbon alpha scale offset no longer matches; skipping.");
+
+    // The bolt Act also runs during gameplay firing.
+    static SafetyHookInline boltHook{};
+    uint8_t* bolt = Memory::PatternScan(baseModule,
+        "48 89 5C 24 08 48 89 74 24 10 57 48 83 EC 30 48 8B 99 E0 00 00 00 48 8B",
+        "MGS 2: Effect Speed Fix : liner_gun_plasma bolt Act");
+    if (bolt)
+    {
+        static void (*boltThunk)(int64_t) = nullptr;
+        boltHook = safetyhook::create_inline(reinterpret_cast<void*>(bolt),
+            static_cast<void (*)(int64_t)>([](int64_t work)
+            {
+                // Hold flight bolts only; the 128-tick impact bolt reads better at native decay.
+                const int lifeMax = work ? *reinterpret_cast<const int32_t*>(work + 0x88) : 0;
+                if (lifeMax <= 64 && MGS2_LinkVarBuf::linkvarbuf &&
+                    ((static_cast<int>(MGS2_LinkVarBuf::GM_StagePlayTime) & 1) == 0))
+                    return;
+                boltHook.call(work);
+            }));
+        LOG_HOOK(boltHook, "MGS 2: Effect Speed Fix : liner_gun_plasma bolt 30fps (gameplay + demo)")
+    }
+
+    // ElectroField must run every frame; its x0.97 fade is authored for 30fps.
+    uint8_t* field = Memory::PatternScan(baseModule,
+        "48 8B C4 53 55 56 57 41 54 41 55 41 56 41 57 48 81 EC D8 00 00 00 0F 29",
+        "MGS 2: Effect Speed Fix : NewElectroField Act");
+    if (!field) return;
+    if (memcmp(field + 0x33E, "\xF3\x0F\x59\x05", 4) != 0)
+    {
+        spdlog::error("MGS 2: Effect Speed Fix: electro field fade offset no longer matches; skipping.");
+        return;
+    }
+    static SafetyHookMid fieldFadeHook{};
+    fieldFadeHook = safetyhook::create_mid(field + 0x346,   // right after: mulss xmm0, [rip] (=0.97)
+        [](SafetyHookContext& ctx)
+        {
+            static bool s_fieldPhase = false;
+            s_fieldPhase = !s_fieldPhase;
+            if (g_GameVars.InCutscene() && s_fieldPhase)
+                ctx.xmm0.f32[0] *= 1.0f / 0.97f;   // net no-op this frame - fade at 30fps
+        });
+    LOG_HOOK(fieldFadeHook, "MGS 2: Effect Speed Fix : NewElectroField 30fps fade")
+
+}
 
 namespace
 {
@@ -163,6 +312,8 @@ namespace
 
 #undef DEFINE_MGS2_FRAMESKIP_HOOK
 
+    MGS2_RAILGUN_PLAYTIME_SKIPS_ALWAYS(DEFINE_MGS2_PLAYTIME_ALWAYS_HOOK)
+
     uintptr_t cigaretteMouthSmokeSpawnAfterLoad = 0;
     uintptr_t cigaretteMouthSmokeSpawnAfterInit = 0;
 
@@ -189,7 +340,6 @@ void EffectSpeedFix::Tick()
     }
 }
 
-
 ///Called on GameVars::OnLevelTransition() to reset counters between cutscenes/levels.
 void EffectSpeedFix::Reset()
 {
@@ -206,7 +356,6 @@ void EffectSpeedFix::Reset()
     }
 }
 
-
 SafetyHookInline solidusFireDashAct_hook {};
 int64_t __fastcall MGS2_solidusFireDashAct(int64_t work)
 {
@@ -214,7 +363,6 @@ int64_t __fastcall MGS2_solidusFireDashAct(int64_t work)
     {
         return solidusFireDashAct_hook.fastcall<int64_t>(work);
     }
-
 
     std::chrono::time_point<std::chrono::high_resolution_clock> current_time = std::chrono::high_resolution_clock::now();
     if (current_time >= g_EffectSpeedFix.solidusDashAct_NextUpdate)
@@ -235,7 +383,6 @@ int64_t __fastcall MGS2_solidusFireDashAct(int64_t work)
 
     return 0;
 }
-
 
 safetyhook::MidHook debrisVelocityHook;
 
@@ -271,21 +418,35 @@ void EffectSpeedFix::Initialize()
     {
         spdlog::error("MGS 2: Effect Speed Fix : rain_slow.c - Failed to find rain_slow copyback address, rain_slow.c frameskip is disabled.");
     }
-    
-
 
 #define INSTALL_MGS2_FRAMESKIP_HOOK(name, pattern, label) \
     CREATE_MGS2_CUTSCENE_FRAMESKIP_HOOK(name, pattern, label);
 
     MGS2_CUTSCENE_FRAMESKIP_INLINE_HOOKS(INSTALL_MGS2_FRAMESKIP_HOOK)
 
+#define CREATE_PLAYTIME_HOOK(name, pattern, label)                                   \
+    if (uint8_t* addr = Memory::PatternScan(baseModule, pattern, label))           \
+    {                                                                              \
+        name##_hook = safetyhook::create_inline(reinterpret_cast<void*>(addr),    \
+            name##_Hook);                                                          \
+        LOG_HOOK(name##_hook, label)                                               \
+    }
+
+    if (MGS2RailgunBeam::bEnabled)
+    {
+        MGS2_RAILGUN_PLAYTIME_SKIPS_ALWAYS(CREATE_PLAYTIME_HOOK)
+    }
+
+#undef CREATE_PLAYTIME_HOOK
+
 #undef INSTALL_MGS2_FRAMESKIP_HOOK
 
-      
+    if (MGS2RailgunBeam::bEnabled) HookRailgunVortexRate(baseModule);
+
         /*
     MGS2_NewSplashPartsSlow_Demo_hook = safetyhook::create_inline(reinterpret_cast<void*>(Memory::PatternScan(baseModule, "40 56 57 48 83 EC ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 44 24 ?? 48 8B F1", "MGS 2: Effect Speed Fix : NewSplashPartsSlow_Demo")), MGS2_NewSplashPartsSlow_Demo_Act_424);
     LOG_HOOK(MGS2_NewSplashPartsSlow_Demo_hook, "MGS 2: Effect Speed Fix : NewSplashPartsSlow_Demo.c")
-    
+
     uintptr_t MGS2_d_splash_parts_slowScanResult = Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "E8 ?? ?? ?? ?? ?? ?? ?? 48 83 C5 ?? 89 43", "MGS 2: Effect Speed Fix : d_splash_parts_slow") + 1);
     MGS2_d_splash_parts_slowScanResult = Memory::GetAbsolute(MGS2_d_splash_parts_slowScanResult + 0x4D);
     MGS2_d_splash_parts_slow_hook = safetyhook::create_inline(reinterpret_cast<void*>(MGS2_d_splash_parts_slowScanResult), MGS2_d_splash_parts_slow_Act_424);
@@ -293,17 +454,14 @@ void EffectSpeedFix::Initialize()
     */
 #pragma endregion
 
-
 #pragma region D012P01
-
 
     if (uint8_t* MGS2_NewFortSplineBulletDemo_Scan = Memory::PatternScan(baseModule, "F6 C1 0F 75 ?? ?? ?? 8B 46 ?? 2B C5 66 0F 6E C0 0F 5B C0 0F 2F 05 ?? ?? ?? ?? 76 ?? 41 0F 28 CD EB ?? F3 0F 59 05 ?? ?? ?? ?? F3 0F 10 0D ?? ?? ?? ?? F3 0F 5C C8 F3 0F 59 3D ?? ?? ?? ?? 4C 8D 46 ?? F3 0F 5C F9 44 0F 2F EF 76 ?? 41 0F 28 FF 41 0F 2F 78 ?? 76 ?? 49 83 C0 20 41 0F 2F 78 ?? 77 ?? 49 8D 50 ?? 45 33 C9 48 8D 4C 24 ?? E8 ?? ?? ?? ?? 0F 28 CF 48 8D 4C 24 ?? 4C 8B C7 E8 ?? ?? ?? ?? 8B 46 ?? 2B C5 66 0F 6E C0 0F 5B C0 F3 0F 5E 05 ?? ?? ?? ?? F3 0F 58 47 ?? F3 0F 11 47 ?? ?? ?? ?? 49 83 C6 20 44 0B F8 48 83 C3 20 48 83 C7 10 FF C5 83 FD 28 0F 8C ?? ?? ?? ?? 44 0F 28 7C 24 ?? 44 0F 28 B4 24 ?? ?? ?? ?? 44 0F 28 AC 24 ?? ?? ?? ?? 44 0F 28 A4 24 ?? ?? ?? ?? 44 0F 28 9C 24 ?? ?? ?? ?? 44 0F 28 94 24 ?? ?? ?? ?? 44 0F 28 8C 24 ?? ?? ?? ?? 44 0F 28 84 24 ?? ?? ?? ?? 0F 28 BC 24 ?? ?? ?? ?? 0F 28 B4 24 ?? ?? ?? ?? 45 85 FF 75 ?? 48 8B CE E8 ?? ?? ?? ?? 83 46 ?? 06 EB ?? FF C0 89 46 ?? 48 8B 4C 24 ?? 48 33 CC E8 ?? ?? ?? ?? 48 8B 9C 24 ?? ?? ?? ?? 48 81 C4 10 01 00 00 41 5F 41 5E 5F 5E 5D C3 CC CC CC CC CC CC CC CC 48 83 EC 38 F3 0F 10 69 ?? ?? ?? ?? 0F 29 74 24 ?? 0F 28 F1 F3 0F 5C 71 ?? 0F 28 DE F3 0F 59 DE 0F 28 E3 0F 28 C3 F3 0F 59 41 ?? F3 0F 59 E6 0F 28 CC 0F 28 D4 F3 0F 59 49 ?? F3 0F 58 C8 0F 28 C6 F3 0F 59 41 ?? F3 0F 5E CD F3 0F 58 C8 0F 28 C3 F3 0F 5E CD ?? ?? ?? ?? ?? ?? ?? ?? ?? F3 0F 59 51 ?? ?? ?? ?? F3 0F 59 41 ?? F3 0F 58 D0 0F 28 C6 F3 0F 59 41 ?? F3 0F 5E D5 F3 0F 58 D0 0F 28 C6 F3 0F 5E D5 F3 0F 58 50 ?? F3 41 0F 11 50 ?? F3 0F 59 61 ?? ?? ?? ?? F3 0F 59 59 ?? F3 0F 59 41 ?? F3 0F 58 E3 F3 0F 5E E5 F3 0F 58 E0 F3 0F 5E E5 F3 0F 58 60 ?? 41 C7 40 ?? 00 00 80 3F F3 41 0F 11 60 ?? 0F 2F 71 ?? 72 ?? 48 8B 51 ?? 45 33 C9 4C 8D 42 ?? E8 ?? ?? ?? ?? 0F 28 74 24 ?? 48 83 C4 38 C3 CC CC CC CC CC CC CC CC CC CC 48 83 EC 48 F3 0F 10 2D ?? ?? ?? ?? F3 41 0F 10 48 ?? 0F 28 D5 F3 0F 10 25 ?? ?? ?? ?? 0F 28 C1 0F 29 74 24 ?? F3 0F 58 C5 F3 41 0F 10 70 ?? 0F 28 DD 0F 29 7C 24 ?? 0F 28 FD 44 0F 29 44 24 ?? F3 0F 5C FE ?? ?? ?? ?? ?? F3 0F 58 F5 44 0F 28 CD F3 41 0F 5C 50 ?? F3 0F 5C 5A ?? F3 0F 59 FA F3 0F 59 F2 F3 0F 10 52 ?? F3 0F 59 F8 0F 28 C5 F3 0F 5C C1 F3 0F 10 4A ?? F3 44 0F 5C C9 44 0F 28 C1 F3 0F 59 FC F3 44 0F 58 C5 F3 0F 59 F0 0F 28 C2 F3 44 0F 59 CB F3 0F 58 C5 F3 44 0F 59 C3 F3 0F 5C EA F3 0F 59 F4 F3 44 0F 59 C0 F3 44 0F 59 CD F3 44 0F 59 C4 F3 44 0F 59 CC 45 85 C9 74 ?? 66 41 0F 6E E9 0F 5B ED F3 0F 11 69", "MGS2: MGS2_NewFortSplineBulletDemo_Scan"))
     {
         Memory::PatchBytes((uintptr_t)MGS2_NewFortSplineBulletDemo_Scan, "\xF6\xC1\x0E", 3);
     }
 
-#pragma endregion 
-
+#pragma endregion
 
     /*
     if (uint8_t* MGS2_flyingSmokeSlowScanResult = Memory::PatternScan(baseModule, "E8 ?? ?? ?? ?? FF 4B ?? 83 7B ?? ?? 7D", "MGS 2: Effect Speed Fix : effect3\\flying_smoke_slow.c"))
@@ -482,25 +640,21 @@ void EffectSpeedFix::Initialize()
         return;
     }
 
-
     if (uint8_t* MGS2_solidusFireDashActScanResult = Memory::PatternScan(baseModule, "?? ?? ?? ?? ?? 49 8D AB 68 FE FF FF 48 81 EC 88", "MGS 2: Effect Speed Fix : effect\\solidas_dash_fire.c"))
     {
         solidusFireDashAct_hook = safetyhook::create_inline(reinterpret_cast<void*>(MGS2_solidusFireDashActScanResult), reinterpret_cast<void*>(MGS2_solidusFireDashAct));
         LOG_HOOK(solidusFireDashAct_hook, "MGS 2: Effect Speed Fix: effect\\solidas_dash_fire.c")
     }
-    
-}
 
+}
 
 ////////
 ///     old tests on broken shit. need to redo these properly. :3
 /*
 #ifdef _MGSDEBUGGING
 
-
     /*
     if (uint8_t* Tidal4Result = Memory::PatternScan(baseModule, "F3 0F 58 83 ?? ?? ?? ?? F3 0F 11 83 ?? ?? ?? ?? 41 0F 28 C3", "MGS 2: Effect Speed Fix : effect\\tidal4.c"))
     {
-
 
 */

--- a/src/fixes/mgs2_demo_blur.cpp
+++ b/src/fixes/mgs2_demo_blur.cpp
@@ -1,5 +1,7 @@
 #include "stdafx.h"
 #include "mgs2_demo_blur.hpp"
+#include <cmath>
+#include <algorithm>
 
 #include "common.hpp"
 #include "d3d11_api.hpp"
@@ -76,8 +78,19 @@ namespace
     bool g_havePrev = false;
     bool g_d3dInit = false, g_d3dFailed = false;
 
+    ID3D11Device* g_boundDevice = nullptr;
+
     bool EnsureD3D(ID3D11Device* dev)
     {
+        // The game recreates its device on some scene transitions - rebuild on change.
+        if (dev != g_boundDevice)
+        {
+            g_d3dInit = false; g_d3dFailed = false; g_havePrev = false;
+            g_prevSRV.Reset(); g_prevTex.Reset(); g_prevW = g_prevH = 0;
+            g_cb.Reset(); g_blend.Reset(); g_rs.Reset(); g_dss.Reset(); g_samp.Reset();
+            g_vs.Reset(); g_ps.Reset();
+            g_boundDevice = dev;
+        }
         if (g_d3dInit) return true;
         if (g_d3dFailed) return false;
         if (!g_D3D11Hooks.D3DCompileFunc) { g_d3dFailed = true; return false; }
@@ -171,7 +184,7 @@ void MGS2DemoBlur::DrawInto(ID3D11RenderTargetView* sceneColor, ID3D11ShaderReso
         g_prevW = bb.Width; g_prevH = bb.Height;
     }
 
-    // The feedback advanced per 30fps demo frame; composite every frame but advance on the demo tick.
+    // Advance every frame; the per-step factor makes two 60Hz steps equal one authored 30fps step.
     static int  s_tickClock = -0x7fffffff;
     static bool s_skip = false;
     if (const int clock = g_GameVars.DG_Clock(); clock != s_tickClock)
@@ -212,7 +225,8 @@ void MGS2DemoBlur::DrawInto(ID3D11RenderTargetView* sceneColor, ID3D11ShaderReso
             D3D11_MAPPED_SUBRESOURCE m;
             if (SUCCEEDED(ctx->Map(g_cb.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &m)))
             {
-                const float cb[4] = { factor, 0, 0, 0 };
+                const float perStep = 1.0f - sqrtf(std::max(0.0f, 1.0f - factor));
+                const float cb[4] = { perStep, 0, 0, 0 };
                 memcpy(m.pData, cb, sizeof(cb));
                 ctx->Unmap(g_cb.Get(), 0);
             }

--- a/src/fixes/mgs2_railgun_beam.cpp
+++ b/src/fixes/mgs2_railgun_beam.cpp
@@ -1,0 +1,222 @@
+#include "stdafx.h"
+#include "mgs2_railgun_beam.hpp"
+
+#include "common.hpp"
+#include "logging.hpp"
+#include "gamevars.hpp"
+#include <d3d11.h>
+#include <wrl/client.h>
+#include <set>
+#include <mutex>
+using Microsoft::WRL::ComPtr;
+
+namespace
+{
+    // Stock sprite vertex shader (Prim.fx SPRITE=1), identified by DXBC digest.
+    constexpr uint8_t kSpriteVSDigest[16] = {
+        0xB1, 0x03, 0x51, 0x1F, 0x89, 0xD7, 0x41, 0xB7, 0xAF, 0x31, 0x0C, 0xD9, 0x77, 0x2C, 0x24, 0x14 };
+    constexpr size_t kSpriteVSSize = 4544;
+
+    // Untextured prims bind an all-white stand-in and go through the doubling shader path; a 0x80 grey twin, substituted per draw for the effect shaders only, restores GS brightness.
+    constexpr uint8_t kPrimVSDigest[16] = {
+        0x92, 0x12, 0x98, 0xF1, 0x43, 0xBD, 0xE0, 0xFC, 0xBC, 0x66, 0xB2, 0xD2, 0x83, 0xD7, 0x14, 0x39 };
+    constexpr size_t kPrimVSSize = 4504;
+
+    std::mutex g_standinMutex;
+    std::set<ID3D11Resource*> g_standins;                 // live 4x4 white stand-in textures
+    ID3D11VertexShader* g_effectVS[16] = {};              // created instances of the effect shaders
+    int g_effectVSCount = 0;
+    ComPtr<ID3D11Texture2D> g_greyTex;
+    ComPtr<ID3D11ShaderResourceView> g_greySRV;
+
+    void RememberEffectVS(ID3D11VertexShader* vs)
+    {
+        if (vs && g_effectVSCount < 16) g_effectVS[g_effectVSCount++] = vs;
+    }
+
+    bool IsEffectVS(ID3D11VertexShader* vs)
+    {
+        for (int i = 0; i < g_effectVSCount; ++i)
+            if (g_effectVS[i] == vs) return true;
+        return false;
+    }
+
+    bool EnsureGreyTwin(ID3D11Device* dev)
+    {
+        if (g_greySRV) return true;
+        static const uint32_t kGrey[16] = {
+            0x80808080,0x80808080,0x80808080,0x80808080, 0x80808080,0x80808080,0x80808080,0x80808080,
+            0x80808080,0x80808080,0x80808080,0x80808080, 0x80808080,0x80808080,0x80808080,0x80808080 };
+        D3D11_TEXTURE2D_DESC td {};
+        td.Width = td.Height = 4; td.MipLevels = 1; td.ArraySize = 1;
+        td.Format = DXGI_FORMAT_B8G8R8A8_UNORM; td.SampleDesc = { 1, 0 };
+        td.Usage = D3D11_USAGE_IMMUTABLE; td.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+        D3D11_SUBRESOURCE_DATA sd { kGrey, 16, 64 };
+        if (FAILED(dev->CreateTexture2D(&td, &sd, g_greyTex.ReleaseAndGetAddressOf()))) return false;
+        return SUCCEEDED(dev->CreateShaderResourceView(g_greyTex.Get(), nullptr, g_greySRV.ReleaseAndGetAddressOf()));
+    }
+
+
+    SafetyHookInline g_createDeviceHook {};
+    SafetyHookInline g_createDeviceSwapHook {};
+    SafetyHookInline g_createVSHook {};
+    SafetyHookInline g_drawIndexedHook {};
+
+
+
+
+
+    void STDMETHODCALLTYPE HookedDrawIndexed(ID3D11DeviceContext* ctx, UINT indexCount,
+        UINT startIndex, INT baseVertex)
+    {
+        if (g_greySRV && g_effectVSCount)
+        {
+            ComPtr<ID3D11VertexShader> vs;
+            ctx->VSGetShader(vs.GetAddressOf(), nullptr, nullptr);
+            if (vs && IsEffectVS(vs.Get()))
+            {
+                ComPtr<ID3D11ShaderResourceView> srv;
+                ctx->PSGetShaderResources(0, 1, srv.GetAddressOf());
+                if (srv)
+                {
+                    ComPtr<ID3D11Resource> res;
+                    srv->GetResource(res.GetAddressOf());
+                    bool standin = false;
+                    if (res)
+                    {
+                        std::lock_guard<std::mutex> lock(g_standinMutex);
+                        standin = g_standins.count(res.Get()) != 0;
+                    }
+                    if (standin)
+                    {
+                        ID3D11ShaderResourceView* grey = g_greySRV.Get();
+                        ctx->PSSetShaderResources(0, 1, &grey);
+                        g_drawIndexedHook.stdcall<void>(ctx, indexCount, startIndex, baseVertex);
+                        ID3D11ShaderResourceView* orig = srv.Get();
+                        ctx->PSSetShaderResources(0, 1, &orig);
+                        return;
+                    }
+                }
+            }
+        }
+        g_drawIndexedHook.stdcall<void>(ctx, indexCount, startIndex, baseVertex);
+    }
+
+
+    SafetyHookInline g_updateSubHook {};
+
+    void STDMETHODCALLTYPE HookedUpdateSubresource(ID3D11DeviceContext* ctx, ID3D11Resource* dst,
+        UINT subresource, const D3D11_BOX* box, const void* data, UINT rowPitch, UINT depthPitch)
+    {
+        if (dst && data)
+        {
+            ComPtr<ID3D11Texture2D> tex;
+            if (SUCCEEDED(dst->QueryInterface(IID_PPV_ARGS(tex.GetAddressOf()))) && tex)
+            {
+                D3D11_TEXTURE2D_DESC td; tex->GetDesc(&td);
+                if (td.Width == td.Height && td.Width <= 64 && subresource == 0 &&
+                    (td.Format == DXGI_FORMAT_B8G8R8A8_UNORM || td.Format == DXGI_FORMAT_R8G8B8A8_UNORM))
+                {
+                    // Stand-ins are all-white squares at several sizes.
+                    bool allWhite = true;
+                    for (UINT y = 0; allWhite && y < td.Height; ++y)
+                    {
+                        const uint32_t* row = reinterpret_cast<const uint32_t*>(
+                            static_cast<const uint8_t*>(data) + static_cast<size_t>(y) * rowPitch);
+                        for (UINT x = 0; x < td.Width; ++x)
+                            if (row[x] != 0xFFFFFFFF) { allWhite = false; break; }
+                    }
+                    std::lock_guard<std::mutex> lock(g_standinMutex);
+                    if (allWhite && g_standins.size() < 64) g_standins.insert(dst);
+                    else if (!allWhite) g_standins.erase(dst);   // real content arrived - untrack
+                }
+            }
+        }
+        g_updateSubHook.stdcall<void>(ctx, dst, subresource, box, data, rowPitch, depthPitch);
+    }
+
+    HRESULT STDMETHODCALLTYPE HookedCreateVertexShader(ID3D11Device* dev, const void* bytecode,
+        SIZE_T length, ID3D11ClassLinkage* linkage, ID3D11VertexShader** out)
+    {
+        const HRESULT hr = g_createVSHook.stdcall<HRESULT>(dev, bytecode, length, linkage, out);
+        if (SUCCEEDED(hr) && bytecode && out && *out &&
+            ((length == kSpriteVSSize && memcmp(static_cast<const uint8_t*>(bytecode) + 4, kSpriteVSDigest, 16) == 0) ||
+             (length == kPrimVSSize && memcmp(static_cast<const uint8_t*>(bytecode) + 4, kPrimVSDigest, 16) == 0)))
+        {
+            RememberEffectVS(*out);
+        }
+        return hr;
+    }
+
+
+    void HookDevice(ID3D11Device* dev)
+    {
+        if (g_createVSHook || !dev) return;
+        void** vtable = *reinterpret_cast<void***>(dev);
+        g_createVSHook = safetyhook::create_inline(vtable[12], reinterpret_cast<void*>(HookedCreateVertexShader));
+        LOG_HOOK(g_createVSHook, "MGS 2: Untextured prim brightness: CreateVertexShader");
+
+        EnsureGreyTwin(dev);
+
+        ComPtr<ID3D11DeviceContext> immCtx;
+        dev->GetImmediateContext(immCtx.GetAddressOf());
+        if (immCtx && !g_updateSubHook)
+        {
+            void** icvt = *reinterpret_cast<void***>(immCtx.Get());
+            g_updateSubHook = safetyhook::create_inline(icvt[48], reinterpret_cast<void*>(HookedUpdateSubresource));
+            LOG_HOOK(g_updateSubHook, "MGS 2: Untextured prim stand-in: UpdateSubresource");
+        }
+
+        ComPtr<ID3D11DeviceContext> ctx;
+        dev->GetImmediateContext(ctx.GetAddressOf());
+        if (ctx && !g_drawIndexedHook)
+        {
+            void** cvt = *reinterpret_cast<void***>(ctx.Get());
+            g_drawIndexedHook = safetyhook::create_inline(cvt[12], reinterpret_cast<void*>(HookedDrawIndexed));
+            LOG_HOOK(g_drawIndexedHook, "MGS 2: Missing-texture effect skip: DrawIndexed");
+        }
+    }
+
+    HRESULT WINAPI HookedD3D11CreateDevice(IDXGIAdapter* adapter, D3D_DRIVER_TYPE driverType,
+        HMODULE software, UINT flags, const D3D_FEATURE_LEVEL* levels, UINT numLevels, UINT sdkVersion,
+        ID3D11Device** dev, D3D_FEATURE_LEVEL* level, ID3D11DeviceContext** ctx)
+    {
+        const HRESULT hr = g_createDeviceHook.stdcall<HRESULT>(adapter, driverType, software, flags,
+            levels, numLevels, sdkVersion, dev, level, ctx);
+        if (SUCCEEDED(hr) && dev && *dev) HookDevice(*dev);
+        return hr;
+    }
+
+    HRESULT WINAPI HookedD3D11CreateDeviceAndSwapChain(IDXGIAdapter* adapter, D3D_DRIVER_TYPE driverType,
+        HMODULE software, UINT flags, const D3D_FEATURE_LEVEL* levels, UINT numLevels, UINT sdkVersion,
+        const DXGI_SWAP_CHAIN_DESC* scDesc, IDXGISwapChain** swap, ID3D11Device** dev,
+        D3D_FEATURE_LEVEL* level, ID3D11DeviceContext** ctx)
+    {
+        const HRESULT hr = g_createDeviceSwapHook.stdcall<HRESULT>(adapter, driverType, software, flags,
+            levels, numLevels, sdkVersion, scDesc, swap, dev, level, ctx);
+        if (SUCCEEDED(hr) && dev && *dev) HookDevice(*dev);
+        return hr;
+    }
+}
+
+void MGS2RailgunBeam::InitializeEarly()
+{
+    if (!(eGameType & MGS2) || !bEnabled) return;
+
+    HMODULE d3d11 = LoadLibraryW(L"d3d11.dll");
+    if (!d3d11)
+    {
+        spdlog::error("MGS 2: Untextured prim brightness: d3d11.dll not found.");
+        return;
+    }
+    if (auto* p = GetProcAddress(d3d11, "D3D11CreateDevice"))
+    {
+        g_createDeviceHook = safetyhook::create_inline(p, reinterpret_cast<void*>(HookedD3D11CreateDevice));
+        LOG_HOOK(g_createDeviceHook, "MGS 2: Untextured prim brightness: D3D11CreateDevice");
+    }
+    if (auto* p = GetProcAddress(d3d11, "D3D11CreateDeviceAndSwapChain"))
+    {
+        g_createDeviceSwapHook = safetyhook::create_inline(p, reinterpret_cast<void*>(HookedD3D11CreateDeviceAndSwapChain));
+        LOG_HOOK(g_createDeviceSwapHook, "MGS 2: Untextured prim brightness: D3D11CreateDeviceAndSwapChain");
+    }
+}

--- a/src/fixes/mgs2_railgun_beam.hpp
+++ b/src/fixes/mgs2_railgun_beam.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+// Untextured prims bind an all-white stand-in texture and render through the colour-doubling
+// shader path, twice as bright as the GS. Substitutes a mid-grey twin for effect draws.
+namespace MGS2RailgunBeam
+{
+    void InitializeEarly();   // hooks D3D11 device creation - call at dll load, before the game boots
+
+    inline bool bEnabled = true;
+
+}

--- a/src/fixes/resolution_scaling_fixes.cpp
+++ b/src/fixes/resolution_scaling_fixes.cpp
@@ -147,20 +147,18 @@ void ResolutionScalingFixes::ApplyFixes()
 
                   });
 
-    MAKE_HOOK_MID(baseModule, "81 E7 ?? ?? ?? ?? BE ?? ?? ?? ?? BA", "NewLinerGunPlasma demo check", {
-        ctx.rdi = 0;  // force demo check false for more nodes
-                  });
-
-
-
-    MAKE_HOOK_MID(baseModule, "?? ?? ?? ?? F3 0F 11 48 ?? E8 ?? ?? ?? ?? 8B C6 8B D3 2B C3 83 F8 ?? 7F ?? 0F 28 74 24 ?? 48 8B 5C 24 ?? 48 8B 74 24 ?? 48 83 C4 ?? 5F C3 ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? F3 0F 10 15", "MGS2: Resolution Scaling Fixes : user\\okajima\\effect2\\liner_gun_plasma.c -> CalcNextNode()", {
-            if (g_GameVars.InCutscene())
-            {
-                ctx.xmm0.f32[0] *= (float)(2.0 * scaleX_fromPs2_4by3);
-                ctx.xmm1.f32[0] *= 2.0f;
-            }
-
-                  });
+    // Disabled: forcing the gameplay path gives 992 plasma nodes where the PS2 demo uses 224 -
+    // a 4.4x additive overstack in cutscenes (Fortune's railgun finale).
+    //MAKE_HOOK_MID(baseModule, "81 E7 ?? ?? ?? ?? BE ?? ?? ?? ?? BA", "NewLinerGunPlasma demo check", {
+    //    ctx.rdi = 0;  // force demo check false for more nodes
+    //              });
+    //MAKE_HOOK_MID(baseModule, "?? ?? ?? ?? F3 0F 11 48 ?? E8 ?? ?? ?? ?? 8B C6 8B D3 2B C3 83 F8 ?? 7F ?? 0F 28 74 24 ?? 48 8B 5C 24 ?? 48 8B 74 24 ?? 48 83 C4 ?? 5F C3 ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? F3 0F 10 15", "MGS2: Resolution Scaling Fixes : user\\okajima\\effect2\\liner_gun_plasma.c -> CalcNextNode()", {
+    //        if (g_GameVars.InCutscene())
+    //        {
+    //            ctx.xmm0.f32[0] *= (float)(2.0 * scaleX_fromPs2_4by3);
+    //            ctx.xmm1.f32[0] *= 2.0f;
+    //        }
+    //              });
 
 
     MAKE_HOOK_MID(baseModule, "66 0F 6E F1 48 8B 4E", "MGS2: user\\shibata\\effect\\2d_sprt.c -> New2dSprite() -> GetResources() @l252 | tanker MGS2 logo", {

--- a/src/resources/config.cpp
+++ b/src/resources/config.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include "fixes/mgs2_railgun_beam.hpp"
 
 #include "common.hpp"
 #include "config.hpp"
@@ -680,7 +681,7 @@ void Config::Read()
 
         if (eGameType & MGS2)
         {
-            g_MGS2UnderwaterFilterFix.bEnabled = g_OpticalCamoFix.bEnabled = MGS2BloodStains::bEnabled = MGS2ScopeWarp::bEnabled = MGS2WaterEffects::bEnabled = MGS2LensDroplets::bEnabled = MGS2GasHaze::bEnabled = MGS2_ContrastShader::bEnabled = MGS2_Crossfade::bEnabled = MGS2ConcentrateBlur::bEnabled = bRestoreVFX;
+            g_MGS2UnderwaterFilterFix.bEnabled = g_OpticalCamoFix.bEnabled = MGS2BloodStains::bEnabled = MGS2ScopeWarp::bEnabled = MGS2WaterEffects::bEnabled = MGS2LensDroplets::bEnabled = MGS2GasHaze::bEnabled = MGS2_ContrastShader::bEnabled = MGS2_Crossfade::bEnabled = MGS2ConcentrateBlur::bEnabled = MGS2RailgunBeam::bEnabled = bRestoreVFX;
 
             ConfigHelper::getValue(ini, ConfigKeys::MotionBlur_Section, ConfigKeys::MotionBlur_Setting, MGS2DemoBlur::bEnabled);
             LOG_CONFIG(ConfigKeys::MotionBlur_Section, ConfigKeys::MotionBlur_Setting, MGS2DemoBlur::bEnabled);


### PR DESCRIPTION
D3D fakes untextured with a white texture through the modulate path, which double-brightens; the PS2's untextured path had no modulate at all, and a mid-grey stand-in makes the fake come out exactly right