### PR TITLE
MGS2: two-sided preshade lighting for black doors and dark poster pools

### DIFF
--- a/MGSHDFix.vcxproj
+++ b/MGSHDFix.vcxproj
@@ -42,6 +42,7 @@
     <ClCompile Include="src\fixes\mgs2_coolant_mirror.cpp" />
     <ClCompile Include="src\features\mgs2_restore_phone_jingle.cpp" />
     <ClCompile Include="src\fixes\mgs2_kirari_sun2_fix.cpp" />
+    <ClCompile Include="src\fixes\mgs2_preshade_lights.cpp" />
     <ClCompile Include="src\fixes\mgs2_snakearm_voice.cpp" />
     <ClCompile Include="src\fixes\resolution_scaling_fixes.cpp" />
     <ClCompile Include="src\features\custom_resolution_and_borderless.cpp" />
@@ -172,6 +173,7 @@
     <ClInclude Include="src\features\mgs3_first_person_view_mode.hpp" />
     <ClInclude Include="src\fixes\mgs2_coolant_mirror.hpp" />
     <ClInclude Include="src\fixes\mgs2_kirari_sun2_fix.hpp" />
+    <ClInclude Include="src\fixes\mgs2_preshade_lights.hpp" />
     <ClInclude Include="src\fixes\mgs2_snakearm_voice.hpp" />
     <ClInclude Include="src\fixes\resolution_scaling_fixes.hpp" />
     <ClInclude Include="src\features\custom_resolution_and_borderless.hpp" />

--- a/MGSHDFix.vcxproj.filters
+++ b/MGSHDFix.vcxproj.filters
@@ -173,6 +173,9 @@
     <ClCompile Include="src\fixes\mgs2_kirari_sun2_fix.cpp">
       <Filter>Fixes</Filter>
     </ClCompile>
+    <ClCompile Include="src\fixes\mgs2_preshade_lights.cpp">
+      <Filter>Fixes</Filter>
+    </ClCompile>
     <ClCompile Include="src\features\mgs2_restore_phone_jingle.cpp">
       <Filter>Features</Filter>
     </ClCompile>
@@ -479,6 +482,9 @@
       <Filter>Fixes\Headers</Filter>
     </ClInclude>
     <ClInclude Include="src\fixes\mgs2_kirari_sun2_fix.hpp">
+      <Filter>Fixes\Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="src\fixes\mgs2_preshade_lights.hpp">
       <Filter>Fixes\Headers</Filter>
     </ClInclude>
     <ClInclude Include="src\features\mgs2_restore_phone_jingle.hpp">

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -74,6 +74,7 @@
 #include "depth_of_field.hpp"
 #include "mg1_custom_loading_screens.hpp"
 #include "mgs2_kirari_sun2_fix.hpp"
+#include "mgs2_preshade_lights.hpp"
 #include "mgs3_fix_camera_offset.hpp"
 #include "mgs3_fix_holster_after_torture.hpp"
 #include "mgs2_msx_colonel.hpp"
@@ -557,6 +558,7 @@ static void InitializeSubsystems()
         INITIALIZE(TextureLiveSwaps::ApplyFixes());
         INITIALIZE(SnakeArmFixes::ApplyFixes());
         INITIALIZE(MGS2_Kirari_Sun2Fix::ApplyFix());
+        INITIALIZE(MGS2PreshadeLights::Initialize());
         INITIALIZE(MGS2_RestoreDogtagViewer::Restore());
         INITIALIZE(g_DepthOfFieldFixes.Initialize());
         INITIALIZE(g_MGS2UnderwaterFilterFix.Initialize());

--- a/src/fixes/mgs2_preshade_lights.cpp
+++ b/src/fixes/mgs2_preshade_lights.cpp
@@ -1,0 +1,44 @@
+#include "stdafx.h"
+
+#include "mgs2_preshade_lights.hpp"
+
+#include "common.hpp"
+#include "logging.hpp"
+
+// Make MGS2's preshade directional and point lights two-sided, so surfaces whose normals face away from a
+// light are lit instead of baking to near-black (fixes black watertight doors and dark poster light pools).
+
+namespace
+{
+    // Half-lambert wrap strength for the directional light (1.0 => i = 0.5*dot + 0.5).
+    constexpr float kWrapScale = 1.0f;
+    // Scale applied to the away-facing side, tuned so front-facing surfaces stay unchanged.
+    constexpr float kBackSideScale = 0.6f;
+}
+
+void MGS2PreshadeLights::Initialize()
+{
+    if (!(eGameType & MGS2))
+    {
+        return;
+    }
+
+    // Directional light: light away-facing normals with a half-lambert wrap instead of clamping to ambient.
+    MAKE_HOOK_MID(baseModule, "F3 0F 5F CA F3 0F 59 F1 F3 0F 59 F9",
+        "MGS 2: Two-Sided Preshade Lighting : system\\libdg\\pshade.c -> BP_ParallelAmbientCalc()", {
+        const float d = ctx.xmm2.f32[0];                        // dot(normal, light direction)
+        const float wrap = kWrapScale * (d * 0.5f + 0.5f);
+        const float back = d < 0.0f ? -d * kBackSideScale : 0.0f;
+        float i = wrap > back ? wrap : back;
+        if (i > 1.0f) i = 1.0f;
+        ctx.xmm1.f32[0] = i;
+    });
+
+    // Point light: apply the scaled away-facing side so those normals receive the light instead of none.
+    MAKE_HOOK_MID(baseModule, "44 0F 2F CE 77 60 0F B6 43 10 0F 28 C2",
+        "MGS 2: Two-Sided Preshade Lighting : system\\libdg\\pshade.c -> BP_PointLightCalc()", {
+        const float d = ctx.xmm6.f32[0];                        // dot(direction-to-vertex, normal)
+        if (d < 0.0f)
+            ctx.xmm6.f32[0] = -d * kBackSideScale;
+    });
+}

--- a/src/fixes/mgs2_preshade_lights.hpp
+++ b/src/fixes/mgs2_preshade_lights.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace MGS2PreshadeLights
+{
+    void Initialize();
+}


### PR DESCRIPTION
MGS2's preshaded (vertex-lit) surfaces are lit one-sided

Front-facing surfaces are unchanged (the away-facing scale is tuned so already-lit geometry doesn't brighten). Two small mid-function hooks on the preshade lighting; no asset changes.

Fixes:
Black watertight / port doors (w03b Deck-2 and similar)
Dark poster light pools
