### PR TITLE
MGS2: Restore Reverb Level

### DIFF
--- a/ConfigTool/tab_data.cpp
+++ b/ConfigTool/tab_data.cpp
@@ -279,6 +279,9 @@ std::nullopt, false, Field::Int, 100, 1, 100},
         {(MGS2), ConfigKeys::MotionBlur_Section, ConfigKeys::MotionBlur_Setting, ConfigKeys::MotionBlur_Help, ConfigKeys::MotionBlur_Tooltip,
           std::nullopt, false, Field::Bool, true },
 
+        { (MGS2), ConfigKeys::MGS2_Restore_Reverb_Level_Section, ConfigKeys::MGS2_Restore_Reverb_Level_Setting, ConfigKeys::MGS2_Restore_Reverb_Level_Help, ConfigKeys::MGS2_Restore_Reverb_Level_Tooltip,
+          std::nullopt, false, Field::Bool, true },
+
         { (MGS2|MGS3), ConfigKeys::FixDepthOfField_Section, ConfigKeys::FixDepthOfField_Setting, ConfigKeys::FixDepthOfField_Help, ConfigKeys::FixDepthOfField_Tooltip,
           std::nullopt, false, Field::Bool, true },
 

--- a/MGSHDFix.vcxproj
+++ b/MGSHDFix.vcxproj
@@ -71,6 +71,7 @@
     <ClCompile Include="src\fixes\mgs2_flare_occlusion.cpp" />
     <ClCompile Include="src\fixes\mgs2_demo_blur.cpp" />
     <ClCompile Include="src\fixes\mgs2_demo_camera_judder.cpp" />
+    <ClCompile Include="src\fixes\mgs2_reverb_wet_level.cpp" />
     <ClCompile Include="src\fixes\mgs2_railgun_beam.cpp" />
     <ClCompile Include="src\features\keep_aiming_after_firing.cpp" />
     <ClCompile Include="src\features\mgs2_sunglasses.cpp" />
@@ -205,6 +206,7 @@
     <ClInclude Include="src\fixes\mgs2_flare_occlusion.hpp" />
     <ClInclude Include="src\fixes\mgs2_demo_blur.hpp" />
     <ClInclude Include="src\fixes\mgs2_demo_camera_judder.hpp" />
+    <ClInclude Include="src\fixes\mgs2_reverb_wet_level.hpp" />
     <ClInclude Include="src\fixes\mgs2_railgun_beam.hpp" />
     <ClInclude Include="src\fixes\mgs2_autopacket.hpp" />
     <ClInclude Include="src\features\keep_aiming_after_firing.hpp" />

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -40,6 +40,7 @@
 #include "mgs2_lens_droplets.hpp"
 #include "mgs2_gas_haze.hpp"
 #include "mgs2_demo_camera_judder.hpp"
+#include "mgs2_reverb_wet_level.hpp"
 #include "mgs2_flare_occlusion.hpp"
 #include "mgs2_railgun_beam.hpp"
 #include "mgs2_demo_blur.hpp"
@@ -552,6 +553,7 @@ static void InitializeSubsystems()
         INITIALIZE(MGS2LensDroplets::Initialize());
         INITIALIZE(MGS2GasHaze::Initialize());
         INITIALIZE(MGS2DemoCameraJudder::Initialize());
+        INITIALIZE(MGS2ReverbWetLevel::Initialize());
         INITIALIZE(MGS2FlareOcclusion::Initialize());
         INITIALIZE(MGS2RailgunBeam::InitializeEarly());
         INITIALIZE(MGS2DemoBlur::Initialize());

--- a/src/fixes/mgs2_reverb_wet_level.cpp
+++ b/src/fixes/mgs2_reverb_wet_level.cpp
@@ -1,0 +1,31 @@
+#include "stdafx.h"
+#include "mgs2_reverb_wet_level.hpp"
+
+#include "common.hpp"
+#include "logging.hpp"
+
+namespace
+{
+    SafetyHookMid gSetWetVolumeHook {};
+}
+
+void MGS2ReverbWetLevel::Initialize()
+{
+    if (!(eGameType & MGS2) || !bEnabled)
+    {
+        return;
+    }
+
+    // Reverb apply: depth -> float, * (1/32767), * master scalar, then IXAudio2Voice::SetVolume
+    // on the reverb submix. Scale the volume in xmm1 just before the call.
+    if (uint8_t* setVolume = Memory::PatternScan(baseModule,
+        "48 8B 8B A0 2E 00 00 0F 5B C9 48 8B 01 F3 0F 59 0D ?? ?? ?? ?? F3 0F 59 8B B8 2E 00 00 FF 50 60",
+        "MGS2: Reverb Wet Level: reverb submix SetVolume"))
+    {
+        gSetWetVolumeHook = safetyhook::create_mid(setVolume + 29, [](SafetyHookContext& ctx)
+        {
+            ctx.xmm1.f32[0] *= MGS2ReverbWetLevel::fWetVolumeScale;
+        });
+        LOG_HOOK(gSetWetVolumeHook, "MGS2: Reverb Wet Level: reverb submix SetVolume")
+    }
+}

--- a/src/fixes/mgs2_reverb_wet_level.hpp
+++ b/src/fixes/mgs2_reverb_wet_level.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+// MGS2: the game correctly drives the PS2 reverb (HALL mode, per-room depth) into an XAudio2
+// reverb submix, but at the PS2 depth values the XAudio2 reverb is much quieter than the
+// PS2's SPU2 hall, so rooms sound nearly dry. Scale the wet volume to compensate.
+namespace MGS2ReverbWetLevel
+{
+    inline bool bEnabled = true;
+
+    // Multiplier on the reverb submix wet volume. 1.0 = vanilla. Chosen by A/B against PS2.
+    inline float fWetVolumeScale = 3.0f;
+
+    void Initialize();
+}

--- a/src/resources/config.cpp
+++ b/src/resources/config.cpp
@@ -15,6 +15,7 @@
 #include "mgs2_gas_haze.hpp"
 #include "mgs2_demo_blur.hpp"
 #include "mgs2_demo_camera_judder.hpp"
+#include "mgs2_reverb_wet_level.hpp"
 #include "mgs2_preshade_lights.hpp"
 #include "mgs2_crossfade.hpp"
 #include "input_handler.hpp"
@@ -687,7 +688,10 @@ void Config::Read()
 
             ConfigHelper::getValue(ini, ConfigKeys::MotionBlur_Section, ConfigKeys::MotionBlur_Setting, MGS2DemoBlur::bEnabled);
             LOG_CONFIG(ConfigKeys::MotionBlur_Section, ConfigKeys::MotionBlur_Setting, MGS2DemoBlur::bEnabled);
-            
+
+            ConfigHelper::getValue(ini, ConfigKeys::MGS2_Restore_Reverb_Level_Section, ConfigKeys::MGS2_Restore_Reverb_Level_Setting, MGS2ReverbWetLevel::bEnabled);
+            LOG_CONFIG(ConfigKeys::MGS2_Restore_Reverb_Level_Section, ConfigKeys::MGS2_Restore_Reverb_Level_Setting, MGS2ReverbWetLevel::bEnabled);
+
 
             ConfigHelper::getValue(ini, ConfigKeys::FixDepthOfField_Section, ConfigKeys::FixDepthOfField_Setting, g_DepthOfFieldFixes.bEnabled);
             LOG_CONFIG(ConfigKeys::FixDepthOfField_Section, ConfigKeys::FixDepthOfField_Setting, g_DepthOfFieldFixes.bEnabled);

--- a/src/resources/config_keys.hpp
+++ b/src/resources/config_keys.hpp
@@ -293,6 +293,13 @@ namespace ConfigKeys
                                                                      "\n"
                                                                      "Higher values increase blur radius but can expose sampling artifacts.";
 
+    constexpr const char* MGS2_Restore_Reverb_Level_Section = "Bugfixes";
+    constexpr const char* MGS2_Restore_Reverb_Level_Setting = "Restore Reverb Level";
+    constexpr const char* MGS2_Restore_Reverb_Level_Help = "";
+    constexpr const char* MGS2_Restore_Reverb_Level_Tooltip = "Raises the reverb wet volume to match the PS2's SPU2 hall reverb.\n"
+                                                              "\n"
+                                                              "The Master Collection's room reverb works but is much too quiet, leaving interiors sounding nearly dry.";
+
     constexpr const char* MGS3_Restore_Film_Grain_Section = "Bugfixes";
     constexpr const char* MGS3_Restore_Film_Grain_Setting = "Fix Film Grain";
     constexpr const char* MGS3_Restore_Film_Grain_Help = "(May Impact Performance)";


### PR DESCRIPTION
Value of 3 for 3 times the PS2 level, which might not translate from SPU -> XAudio exactly. Left as a tuning exercise for people with time and spectral analysis :)