### PR TITLE
Mgs2 demo support - allows customised demos to run with extra effects / models / textures.

### DIFF
--- a/MGSHDFix.vcxproj
+++ b/MGSHDFix.vcxproj
@@ -14,6 +14,7 @@
     <ClCompile Include="src\fixes\color_correction.cpp" />
     <ClCompile Include="src\features\mgs2_vamp_punch_fix.cpp" />
     <ClCompile Include="src\fixes\mgs2_newscrconcentrateblur.cpp" />
+    <ClCompile Include="src\fixes\mgs2_enhanced_demos.cpp" />
     <ClCompile Include="src\resources\d3d11_text_overlay.cpp" />
     <ClCompile Include="src\resources\mgs2_status_flags.cpp" />
     <ClCompile Include="src\resources\game_funcs.cpp" />
@@ -155,6 +156,7 @@
     <ClInclude Include="src\features\mgs2_vamp_punch_fix.hpp" />
     <ClInclude Include="src\fixes\mgs2_crossfade.hpp" />
     <ClInclude Include="src\fixes\mgs2_newscrconcentrateblur.hpp" />
+    <ClInclude Include="src\fixes\mgs2_enhanced_demos.hpp" />
     <ClInclude Include="src\resources\d3d11_text_overlay.hpp" />
     <ClInclude Include="src\resources\game_defines.hpp" />
     <ClInclude Include="src\resources\game_funcs.hpp" />

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -98,6 +98,7 @@
 #include "mgs2_shimmer.hpp"
 #include "mgs2_crossfade.hpp"
 #include "mgs2_newscrconcentrateblur.hpp"
+#include "mgs2_enhanced_demos.hpp"
 #include "playtime_fixes.hpp"
 #include "mgs2_snake_tales_radar.hpp"
 #include "mgs2_thermal_goggles.hpp"
@@ -589,6 +590,7 @@ static void InitializeSubsystems()
         INITIALIZE(MGS2RayPhotoVoice::Initialize());
         INITIALIZE(MGS2_ContrastShader::Setup());
         INITIALIZE(MGS2ConcentrateBlur::Initialize());
+        INITIALIZE(MGS2EnhancedDemos::Initialize());
         INITIALIZE(CaptionReplacements::Setup());
         INITIALIZE(SMAA_AA::CompileShaders());
         INITIALIZE(ScreenspaceFixes::Apply());

--- a/src/features/expand_bp_assets.cpp
+++ b/src/features/expand_bp_assets.cpp
@@ -1,6 +1,8 @@
 #include "stdafx.h"
 #include <filesystem>
 #include <string>
+#include <vector>
+#include <algorithm>
 
 #include "expand_bp_assets.hpp"
 
@@ -41,6 +43,30 @@ static inline size_t RoundUp(size_t size) {
 	while (ret < size)
 		ret <<= 1;
 	return ret;
+}
+
+// Key on the cache fields, not the source path. One texture can be registered against
+// several tri groups, and those lines differ only in the last field.
+static inline std::string_view CacheKey(const std::string& line) {
+	const size_t comma = line.find(',');
+	return comma == std::string::npos ? std::string_view(line) : std::string_view(line).substr(comma + 1);
+}
+
+static void SplitLines(const char* data, size_t size, std::vector<std::string>& out) {
+	size_t start = 0;
+	for (size_t i = 0; i <= size; i++) {
+		if (i != size && data[i] != '\n') {
+			continue;
+		}
+		size_t end = i;
+		while (end > start && (data[end - 1] == '\r' || data[end - 1] == '\n')) {
+			end--;
+		}
+		if (end > start) {
+			out.emplace_back(data + start, end - start);
+		}
+		start = i + 1;
+	}
 }
 
 static inline void* LoadSimilarFiles(BPLoadFileState* state, bool isBPAssets) {
@@ -93,19 +119,46 @@ static inline void* LoadSimilarFiles(BPLoadFileState* state, bool isBPAssets) {
 		}
 	}
 	
-	// Put the vanilla data last, to ensure the modded data takes priority
+	// Merge instead of prepending. A cache path the stage already lists replaces it in
+	// place, since loading an asset twice starves the streamer and runs the stage in slow
+	// motion. New entries go on the end: the list is in dependency order.
 	size_t newFilesSize = state->currentFileSize - originalFileSize;
 	if (newFilesSize) {
-		char* originalFileBuffer = (char*)malloc(originalFileSize);
-		char* newFilesBuffer = (char*)malloc(newFilesSize);
-		memcpy(originalFileBuffer, *buffer, originalFileSize);
-		memcpy(newFilesBuffer, &(*buffer)[originalFileSize], newFilesSize);
-		
-		memcpy(*buffer, newFilesBuffer, newFilesSize);
-		memcpy(&(*buffer)[newFilesSize], originalFileBuffer, originalFileSize);
+		std::vector<std::string> lines, extra;
+		SplitLines(*buffer, originalFileSize, lines);
+		SplitLines(&(*buffer)[originalFileSize], newFilesSize, extra);
 
-		free(originalFileBuffer);
-		free(newFilesBuffer);
+		size_t replaced = 0, added = 0;
+		for (const std::string& line : extra) {
+			const std::string_view key = CacheKey(line);
+			auto match = std::find_if(lines.begin(), lines.end(),
+				[&](const std::string& v) { return CacheKey(v) == key; });
+			if (match != lines.end()) {
+				*match = line;
+				replaced++;
+			}
+			else {
+				lines.push_back(line);
+				added++;
+			}
+		}
+
+		std::string merged;
+		merged.reserve(state->currentFileSize + 2 * lines.size() + 1);
+		for (const std::string& line : lines) {
+			merged += line;
+			merged += "\r\n";
+		}
+
+		const size_t needed = RoundUp(merged.size() + 1);
+		if (needed > prevBufferSize) {
+			*buffer = (char*)realloc(*buffer, needed);
+		}
+		memcpy(*buffer, merged.data(), merged.size());
+		(*buffer)[merged.size()] = '\0';
+		state->currentFileSize = merged.size();
+		spdlog::info("{}: merged {} supplementary entries ({} replaced, {} added)",
+			std::filesystem::path(filePath).filename().string(), extra.size(), replaced, added);
 	}
 
 	return state->currentFileHandle;

--- a/src/fixes/mgs2_enhanced_demos.cpp
+++ b/src/fixes/mgs2_enhanced_demos.cpp
@@ -1,0 +1,181 @@
+#include "stdafx.h"
+#include "mgs2_enhanced_demos.hpp"
+
+#include "common.hpp"
+#include "logging.hpp"
+
+#include "game_funcs.hpp"
+#include "gamevars.hpp"
+
+#include <unordered_map>
+#include <vector>
+
+// Cutscene mod support: any effect chara id works in any stage, and the effect prim
+// pool is bigger for dense scenes. Stock demos are unaffected.
+namespace
+{
+    SafetyHookInline gGetCharaIDHook {};
+
+    std::unordered_map<uint32_t, void*> gUnion;
+    bool gUnionBuilt = false;
+
+    // Stage chara tables: sorted static CHARA arrays (game_funcs.hpp)
+
+    void BuildUnion()
+    {
+        gUnionBuilt = true;
+
+        const auto base = reinterpret_cast<uintptr_t>(baseModule);
+        const auto* dos = reinterpret_cast<const IMAGE_DOS_HEADER*>(base);
+        const auto* nt = reinterpret_cast<const IMAGE_NT_HEADERS*>(base + dos->e_lfanew);
+
+        uintptr_t textLo = 0, textHi = 0;
+        std::vector<std::pair<uintptr_t, uintptr_t>> dataSecs;
+        const auto* sec = IMAGE_FIRST_SECTION(nt);
+        for (unsigned i = 0; i < nt->FileHeader.NumberOfSections; i++, sec++)
+        {
+            const uintptr_t lo = base + sec->VirtualAddress;
+            const uintptr_t hi = lo + sec->Misc.VirtualSize;
+            if (sec->Characteristics & IMAGE_SCN_MEM_EXECUTE)
+            {
+                if (textLo == 0) { textLo = lo; textHi = hi; }
+                else { textHi = hi > textHi ? hi : textHi; }
+            }
+            else if ((sec->Characteristics & IMAGE_SCN_MEM_READ)
+                  && (sec->Characteristics & IMAGE_SCN_CNT_INITIALIZED_DATA))
+            {
+                dataSecs.emplace_back(lo, hi);
+            }
+        }
+
+        const auto valid = [&](const CHARA* r)
+        {
+            // the alignment padding after class_id is always zero in the static tables
+            return r->class_id > 0 && r->class_id < 0x02000000
+                && reinterpret_cast<const uint32_t*>(r)[1] == 0
+                && reinterpret_cast<uintptr_t>(r->new_) >= textLo
+                && reinterpret_cast<uintptr_t>(r->new_) < textHi;
+        };
+
+        size_t tables = 0;
+        for (const auto& [lo, hi] : dataSecs)
+        {
+            const auto* end = reinterpret_cast<const uint8_t*>(hi) - sizeof(CHARA) * 2;
+            for (const auto* q = reinterpret_cast<const uint8_t*>(lo); q <= end; q += 8)
+            {
+                const auto* r = reinterpret_cast<const CHARA*>(q);
+                if (!valid(r) || !valid(r + 1) || (r + 1)->class_id <= r->class_id)
+                {
+                    continue;
+                }
+                size_t n = 1;
+                const CHARA* rr = r;
+                while (reinterpret_cast<const uint8_t*>(rr + 2) <= reinterpret_cast<const uint8_t*>(hi)
+                    && valid(rr + 1) && (rr + 1)->class_id > rr->class_id)
+                {
+                    rr++;
+                    n++;
+                }
+                if (n >= 12)
+                {
+                    for (const CHARA* k = r; k <= rr; k++)
+                    {
+                        void* fn = reinterpret_cast<void*>(k->new_);
+                        const auto [at, added] = gUnion.emplace(k->class_id, fn);
+                        if (!added && at->second != fn)
+                        {
+                            // the union is only sound while an id means one function
+                            spdlog::warn("MGS 2: Enhanced Demos: chara {:08x} has two constructors ({} and {}), keeping the first.",
+                                k->class_id, at->second, fn);
+                        }
+                    }
+                    tables++;
+                }
+                q = reinterpret_cast<const uint8_t*>(rr + 1) - 8;
+            }
+        }
+        spdlog::info("MGS 2: Enhanced Demos: harvested {} chara tables, {} unique ids.", tables, gUnion.size());
+    }
+
+    void* GetCharaID_Detour(int nID)
+    {
+        // The stock lookup asserts on a miss, so check the union first. An id maps
+        // to the same function in every stage table that carries it.
+        if (!gUnionBuilt)
+        {
+            BuildUnion();
+        }
+        const auto it = gUnion.find(static_cast<uint32_t>(nID));
+        if (it != gUnion.end())
+        {
+            return it->second;
+        }
+        return gGetCharaIDHook.call<void*>(nID);
+    }
+
+    void PatchPrim2Pool()
+    {
+        // The prim2 pool fills up in dense scenes and effects stop drawing. Raise it to
+        // 2048; the buffer advance after it has to match.
+        uint8_t* anchor = g_GameVars.DG_InitChanlSystem_ObjQueueInit();
+        if (anchor == nullptr)
+        {
+            return;
+        }
+        // prim2 is the last of the four 512-slot buffers set up after this one. Bail if
+        // there aren't exactly four, the layout has changed.
+        uint8_t* store = nullptr;
+        int stores = 0;
+        for (uint8_t* p = anchor; p < anchor + 0x100; p++)
+        {
+            if (p[0] == 0x48 && p[1] == 0xC7 && p[2] == 0x05
+             && p[7] == 0x00 && p[8] == 0x02 && p[9] == 0x00 && p[10] == 0x00)
+            {
+                if (++stores == 4)
+                {
+                    store = p;
+                }
+            }
+        }
+        uint8_t* lea = nullptr;
+        for (uint8_t* p = anchor; p < anchor + 0x100; p++)
+        {
+            if (p[0] == 0x8D && p[1] == 0x81
+             && p[2] == 0x00 && p[3] == 0x02 && p[4] == 0x00 && p[5] == 0x00)
+            {
+                lea = p;
+                break;
+            }
+        }
+        if (store == nullptr || lea == nullptr || stores != 4)
+        {
+            spdlog::error("MGS 2: Enhanced Demos: DG_InitChanlSystem() carves {} buffers of 512, expected 4.", stores);
+            return;
+        }
+        Memory::Write<int>(reinterpret_cast<uintptr_t>(store + 7), 2048);
+        Memory::Write<int>(reinterpret_cast<uintptr_t>(lea + 2), 2048);
+        spdlog::info("MGS 2: Enhanced Demos: DG_ObjQueue prim2 pool 512 -> 2048.");
+    }
+}
+
+void MGS2EnhancedDemos::Initialize()
+{
+    if (!(eGameType & MGS2))
+    {
+        return;
+    }
+
+    spdlog::info("MGS 2: Enhanced Demos - Initializing...");
+
+    uint8_t* site = Memory::PatternScan(baseModule,
+        "E8 ?? ?? ?? ?? 48 8B F0 48 85 C0 75 ?? 8D 46 ?? 48 83 C4",
+        "MGS 2: Enhanced Demos: NewChara() -> GM_GetCharaID");
+    if (site == nullptr)
+    {
+        return;
+    }
+    gGetCharaIDHook = safetyhook::create_inline(Memory::ResolveCall(site), GetCharaID_Detour);
+    LOG_HOOK(gGetCharaIDHook, "MGS 2: Enhanced Demos - GM_GetCharaID");
+
+    PatchPrim2Pool();
+}

--- a/src/fixes/mgs2_enhanced_demos.hpp
+++ b/src/fixes/mgs2_enhanced_demos.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace MGS2EnhancedDemos
+{
+    void Initialize();
+}

--- a/src/resources/game_funcs.hpp
+++ b/src/resources/game_funcs.hpp
@@ -1,5 +1,13 @@
 #pragma once
 
+// One entry of a stage chara table (chara.h CHARA_TABLE)
+struct CHARA
+{
+    unsigned int class_id;
+    void* (__fastcall* new_)(int, int);
+};
+static_assert(sizeof(CHARA) == 0x10);
+
 namespace Shared_Gamefuncs
 {
     void HookFuncs();

--- a/src/resources/gamevars.cpp
+++ b/src/resources/gamevars.cpp
@@ -42,6 +42,7 @@ void GameVars::Initialize()
         // system/libdg/frame.cpp -> DG_StartFrame() loads both globals before its undraw test.
         p_DG_UnDrawFrameCount64 = reinterpret_cast<int64_t*>(Memory::GetRipRelativeAddress(Memory::PatternScan(baseModule, "48 8B 0D ?? ?? ?? ?? BF", "MGS2: DG_UnDrawFrameCount64"), 3, 7));
         p_DG_LastWhich = reinterpret_cast<int*>(Memory::GetRipRelativeAddress(Memory::PatternScan(baseModule, "8B 05 ?? ?? ?? ?? 8B DF", "MGS2: DG_LastWhich"), 2, 6));
+        p_DG_ObjQueueInit = Memory::PatternScan(baseModule, "48 C7 05 ?? ?? ?? ?? 00 03 00 00", "MGS 2: GameVars: DG_InitChanlSystem() -> DG_ObjQueue init");
         p_DG_Chanls = reinterpret_cast<DG_CHANL*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 8B CB", "MGS2: DG_Chanls") + 3));
         p_GM_CurrentStageMap = reinterpret_cast<int32_t*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "8B 1D ?? ?? ?? ?? E8 ?? ?? ?? ?? 8B F8", "MGS2: GM_CurrentStageMap") + 2));
 

--- a/src/resources/gamevars.hpp
+++ b/src/resources/gamevars.hpp
@@ -130,6 +130,7 @@ public:
     [[nodiscard]] int& DG_Clock() const;
     [[nodiscard]] int& DG_LastWhich() const; // >= 0 when DG_StartFrame skipped drawing the frame.
     [[nodiscard]] int64_t DG_UnDrawFrameCount() const; // Frames still scheduled undrawn.
+    [[nodiscard]] uint8_t* DG_InitChanlSystem_ObjQueueInit() const { return p_DG_ObjQueueInit; }
 
     [[nodiscard]] static constexpr uint32_t GV_StrCode(const char* inputString)
     {
@@ -173,6 +174,7 @@ private:
     int* p_DG_LastWhich = nullptr;
     int64_t* p_DG_UnDrawFrameCount64 = nullptr; // MGS2 declares it long64, MGS3 long
     int32_t* p_DG_UnDrawFrameCount32 = nullptr;
+    uint8_t* p_DG_ObjQueueInit = nullptr;
     DG_CHANL* p_DG_Chanls = nullptr;
 
     int32_t* p_GM_CurrentStageMap = nullptr;


### PR DESCRIPTION
Tested in all locales, partial overrides, root override only, root override with child (jp) override, and they all return expected results.

Tested with removing the demo override and leaving manifests (works, but not encouraged as assets load into scene, that is the mods choice, we just do what we're told).

Tested on Steam deck with test mod (Arsenal Gear!).

**What this adds**

**Enhanced demos**

Effect charas are normally per-stage, so if a demo tries to use an effect that isn't in that stage's table it simply fails. The patch builds a union of every stage's effect table, so any effect can be used anywhere.

It also increases the effect primitive pool from 512 → 2048. Big scenes used to silently stop drawing effects once the pool filled up.


**bp_assets / manifest merge fix**

Supplementary bp_assets_*.txt files technically already existed, but they were unusable in cutscene stages because they'd make everything run in slow motion.

Turns out the game was prepending the entire list, so duplicate entries ended up registering twice, loading twice, and starving the streamer.

It now merges them properly instead: existing cache paths are replaced in place, genuinely new entries are appended. Entries are matched on their cache paths rather than the source filename, so you can point a new file at an existing slot, and a texture legitimately registered against several triies.

**Where to look**

If you're interested in how it all works, the comments in the source explain the implementation.

- src/fixes/mgs2_enhanced_demos.cpp — effect table union and expanded primitive pool
- src/features/expand_bp_assets.cpp — manifest merge behaviour

**Adding an effect**

Nothing special any more.

Just use whatever effect chara ID you want. It doesn't matter which stage originally owned

**Adding a texture**

Good news: this needs no patch at all, the game already supports it. It just isn't obvious

New texture IDs are declared in a .tri, and the pixels come from a .ctxr in the game's own flatlist override folder:

textures\flatlist\ovr_stm\_win\005b0000.ctxr

Take the .tri your model's materials look up, add an entry per new ID, and ship it under a new name (land_high_mymod.tri) with a manifest line pointing at the original's cache slot:

assets/tri/us/land_high_mymod.tri,us/stage/d080p07/cache/0094d596.tri,cache/0094d596.tri

Then register each texture against that same slot — note the tri hash in the last field, that's what ties the texture to the group:

textures/flatlist/005b0000.ctxr,stage/d080p07/cache/005b0000.ctxr,eu/stage/d080p07/cache/0094d596/005b0000.ctxr

You get completely new IDs at any resolution, referenced exactly like vanilla ones, so multiple mods can share a texture without stepping on each other.

Tris are authored different for PS2 vs MC.

**Adding a model**

There are really only three steps.

Put your model files in:

assets\kms\us\yourmodel.kms
assets\kms\us\yourmodel.cmdl

Register them in your own supplementary files (manifest_yourmod.txt and bp_assets_yourmod.txt):

assets/kms/us/yourmodel.kms,us/stage/<stage>/cache/<strcode>.kms,cache/<strcode>.kms
assets/kms/us/yourmodel.cmdl,us/stage/<stage>/cache/<strcode>.cmdl,<region>/stage/<stage>/cache/<strcode>.cmdl

<strcode> is simply the model's StrCode in hexadecimal.

Finally, any texture IDs your materials reference need declaring as above.

One thing that caught me out for ages: register the model after the .tri that contains its textures.

The lists are processed in dependency order, not alphabetically. If the model comes first it'll load perfectly... but render completely grey because the texture bindings are resolved once when the model loads, and at that point the textures don't exist yet.

Appending your entries to the end of the lists is always the safe option.

**Putting a model into a custom demo**

Whatever tools you're using, the process is roughly the same.

Export your .kms and .cmdl (SeaLouse can do this directly from Blender), then register them as above.

Next, create the object in the stage scenario. Demos can't spawn geometry on their own — they can only manipulate objects that already exist. So the stage's .gcx needs a hidden put-object during initialisation. That's the only part that currently has no shortcut; you'll need the GCL toolchain to rebuild the scenario.

Drop the rebuilt .gcx into:

update\assets\gcx\<region>\_bp\

so you're overriding it cleanly instead of replacing the original, using this method https://github.com/ThirteenAG/Ultimate-ASI-Loader#update-folder-overload-from-folder

Do both eu and us. The Japanese build reads its stage lists and demo from jp\, but it loads the US scenario

Once the object exists, the .sdt controls it by StrCode with normal put-object messages: show, hide, move, rotate, etc. That's how you make an object slide into frame, appear on a cut, or animate during the scene. Effects are just fired frame-by-frame in the same way.

One last thing that's worth knowing because it looks like a completely random crash otherwise: the game has a hard limit of 512 effect births for the entire demo. That's total births across the whole cutscene, not 512 active at once, and it never resets. Go over the limit and you'll get aen the 512th effect is created. This could be extended, but not in scope right now.

**Count your effects.**

Everything ships non-destructively too. The demo lives under <region>\demo2\_bp\ovr_stm, the scenario goes in the gcx override folder, models and textures are all new files, and registrations live in supplementary manifests.

Nothing in the original game is modified, and uninstalling a mod is just deleting the files you added.