### PR TITLE
Hold frames the engine skipped drawing

### DIFF
--- a/MGSHDFix.vcxproj
+++ b/MGSHDFix.vcxproj
@@ -60,6 +60,7 @@
     <ClCompile Include="src\fixes\depth_of_field.cpp" />
     <ClCompile Include="src\fixes\mgs2_underwater_filter.cpp" />
     <ClCompile Include="src\fixes\mgs3_film_grain.cpp" />
+    <ClCompile Include="src\fixes\mgs3_crossfade_capture.cpp" />
     <ClCompile Include="src\fixes\mgs3_hud_fixes.cpp" />
     <ClCompile Include="src\fixes\optical_camo.cpp" />
     <ClCompile Include="src\fixes\windows_fullscreen_optimization.cpp" />
@@ -208,6 +209,7 @@
     <ClInclude Include="src\fixes\depth_of_field.hpp" />
     <ClInclude Include="src\fixes\mgs2_underwater_filter.hpp" />
     <ClInclude Include="src\fixes\mgs3_film_grain.hpp" />
+    <ClInclude Include="src\fixes\mgs3_crossfade_capture.hpp" />
     <ClInclude Include="src\fixes\mgs3_hud_fixes.hpp" />
     <ClInclude Include="src\fixes\aiming_full_tilt.hpp" />
     <ClInclude Include="src\fixes\mgs2_blood_stains.hpp" />

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -55,6 +55,7 @@
 #include "water_reflections.hpp"
 #include "mgs3_hud_fixes.hpp"
 #include "mgs3_film_grain.hpp"
+#include "mgs3_crossfade_capture.hpp"
 #include "windows_fullscreen_optimization.hpp"
 #include "busy_loop_fix.hpp"
 #include "mgs2_snakearm_voice.hpp"
@@ -598,6 +599,7 @@ static void InitializeSubsystems()
         INITIALIZE(g_WaterReflectionFix.Initialize());
         INITIALIZE(MGS3HudFixes::Initialize());
         INITIALIZE(MGS3FilmGrain::Initialize());
+        INITIALIZE(MGS3_CrossfadeCapture::Initialize());
         INITIALIZE(MGS3FixCameraOffset::Activate());
         INITIALIZE(g_DepthOfFieldFixes.Initialize());
         INITIALIZE(CaptionReplacements::Setup());

--- a/src/fixes/mgs3_crossfade_capture.cpp
+++ b/src/fixes/mgs3_crossfade_capture.cpp
@@ -31,7 +31,7 @@ bool MGS3_CrossfadeCapture::ReleaseWindowTick()
 void MGS3_CrossfadeCapture::Initialize()
 {
     uint8_t* dieAddr = Memory::PatternScan(baseModule,
-        "48 8B C4 48 89 58 08 48 89 70 10 57 48 83 EC ?? 33 F6 48 8B D9 39 B1 ?? ?? ?? ?? 75 ?? 89 70 E8",
+        "48 8B C4 48 89 58 ?? 48 89 70 ?? 57 48 83 EC ?? 33 F6",
         "MGS 3: Crossfade : user\\takabe\\effect\\crosfade.c -> NewCrossFadeEffect() -> Die()");
     if (dieAddr)
     {

--- a/src/fixes/mgs3_crossfade_capture.cpp
+++ b/src/fixes/mgs3_crossfade_capture.cpp
@@ -32,7 +32,7 @@ void MGS3_CrossfadeCapture::Initialize()
 {
     uint8_t* dieAddr = Memory::PatternScan(baseModule,
         "48 8B C4 48 89 58 08 48 89 70 10 57 48 83 EC ?? 33 F6 48 8B D9 39 B1 ?? ?? ?? ?? 75 ?? 89 70 E8",
-        "MGS 3: Crossfade : user\\takabe\\effect\\crosfade.c -> Die()");
+        "MGS 3: Crossfade : user\\takabe\\effect\\crosfade.c -> NewCrossFadeEffect() -> Die()");
     if (dieAddr)
     {
         dieHook = safetyhook::create_inline(dieAddr, reinterpret_cast<void*>(Die_Detour));

--- a/src/fixes/mgs3_crossfade_capture.cpp
+++ b/src/fixes/mgs3_crossfade_capture.cpp
@@ -1,0 +1,41 @@
+#include "stdafx.h"
+#include "mgs3_crossfade_capture.hpp"
+
+#include "common.hpp"
+#include "logging.hpp"
+
+// The crossfade captures the scene through the renderer's store path, and its teardown can
+// present one ungraded frame ~3 presents after the actor dies. Arm a short window there so
+// the double-render check in HoldPreviousFrame only ever runs where the race lives.
+namespace
+{
+    SafetyHookInline dieHook {};
+    std::atomic<int> g_releaseWindow = 0;
+
+    void __fastcall Die_Detour(void* work)
+    {
+        g_releaseWindow.store(8, std::memory_order_relaxed);
+        dieHook.fastcall<void>(work);
+    }
+}
+
+bool MGS3_CrossfadeCapture::ReleaseWindowTick()
+{
+    int v = g_releaseWindow.load(std::memory_order_relaxed);
+    while (v > 0 && !g_releaseWindow.compare_exchange_weak(v, v - 1, std::memory_order_relaxed))
+    {
+    }
+    return v > 0;
+}
+
+void MGS3_CrossfadeCapture::Initialize()
+{
+    uint8_t* dieAddr = Memory::PatternScan(baseModule,
+        "48 8B C4 48 89 58 08 48 89 70 10 57 48 83 EC ?? 33 F6 48 8B D9 39 B1 ?? ?? ?? ?? 75 ?? 89 70 E8",
+        "MGS 3: Crossfade : user\\takabe\\effect\\crosfade.c -> Die()");
+    if (dieAddr)
+    {
+        dieHook = safetyhook::create_inline(dieAddr, reinterpret_cast<void*>(Die_Detour));
+        LOG_HOOK(dieHook, "MGS 3: Crossfade : user\\takabe\\effect\\crosfade.c -> Die()");
+    }
+}

--- a/src/fixes/mgs3_crossfade_capture.hpp
+++ b/src/fixes/mgs3_crossfade_capture.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace MGS3_CrossfadeCapture
+{
+    void Initialize();
+    bool ReleaseWindowTick(); // call once per present; true while inside a crossfade-teardown window
+}

--- a/src/resources/d3d11_api.cpp
+++ b/src/resources/d3d11_api.cpp
@@ -3,6 +3,7 @@
 #include "common.hpp"
 #include "d3d11_api.hpp"
 
+#include "gamevars.hpp"
 #include "gpu_check.hpp"
 #include "logging.hpp"
 
@@ -40,27 +41,49 @@ namespace
     using ResizeBuffersFn = HRESULT(__stdcall*)(IDXGISwapChain*, UINT, UINT, UINT, DXGI_FORMAT, UINT);
     ResizeBuffersFn oResizeBuffers = nullptr;
 
-    // A frame-skip catch-up renders two game frames inside one present; the second one
-    // skips its glow/grade pass, so showing it flashes a dim ungraded frame (worst at
-    // crossfade ends). The PS2 never displayed skipped frames - hold the previous image.
+    // The PS2 never presented a frame it hadn't drawn; the port does, and it flashes dim.
     ComPtr<ID3D11Texture2D> g_heldFrame;
     UINT g_heldW = 0, g_heldH = 0;
     bool g_heldValid = false;
 
-    bool IsMergedPresent()
-    {
-        static uint32_t lastShadowSets = 0;
-        static bool mergedLast = false;
+    // A stage load parks DG_UnDrawFrameCount at DG_UNDRAW_MAX, and the port draws its own
+    // loading screen through those frames, so hold only the short scheduled runs.
+    constexpr int64_t kMaxHeldRun = 64;
 
-        const uint32_t shadowSets = SceneDepth::ReadAndResetShadowSetCount();
-        const bool merged = !mergedLast && lastShadowSets >= 2 && shadowSets >= lastShadowSets * 2;
-        lastShadowSets = shadowSets;
-        mergedLast = merged;
-        return merged;
+    // DG_StartFrame clears DG_LastWhich to -1 only on the path that draws.
+    bool IsUnDrawnFrame()
+    {
+        return g_GameVars.DG_LastWhich() >= 0 && g_GameVars.DG_UnDrawFrameCount() <= kMaxHeldRun;
+    }
+
+    // A crossfade draws the scene twice in one frame and the second pass misses the glow/grade
+    // build. Gated to cutscenes - a count change during gameplay is just scenery coming into view.
+    bool IsDoubleRenderedFrame(uint32_t shadowSets)
+    {
+        static uint32_t history[4] {};
+        static size_t head = 0;
+        static bool firedLast = false;
+
+        const uint32_t prev = history[(head + std::size(history) - 1) % std::size(history)];
+        bool steady = prev >= 2;
+        for (const uint32_t s : history)
+        {
+            steady = steady && s == prev;
+        }
+
+        const bool doubled = !firedLast && steady && shadowSets == prev * 2;
+        history[head] = shadowSets;
+        head = (head + 1) % std::size(history);
+        firedLast = doubled;
+
+        return doubled && g_GameVars.InScriptedSequence();
     }
 
     void HoldPreviousFrame(IDXGISwapChain* swap)
     {
+        // Consume the count every present, before any bail-out, or it accrues into a false double.
+        const bool doubleRendered = IsDoubleRenderedFrame(SceneDepth::ReadAndResetShadowSetCount());
+
         auto* device = g_D3D11Hooks.d3dDevice.Get();
         auto* context = g_D3D11Hooks.d3dDeviceContext.Get();
         if (!device || !context || !swap)
@@ -94,11 +117,13 @@ namespace
             g_heldH = bb.Height;
         }
 
-        if (IsMergedPresent() && g_heldValid)
+        const bool undrawn = IsUnDrawnFrame();
+        if ((undrawn || doubleRendered) && g_heldValid)
         {
             if (g_Logging.bVerboseLogging)
             {
-                spdlog::info("D3D11Hooks: merged frame detected, holding previous image.");
+                spdlog::info("D3D11Hooks: {} frame, holding previous image. (stage={})",
+                    undrawn ? "undrawn" : "double-rendered", g_GameVars.GetCurrentStage());
             }
             context->CopyResource(backbuffer.Get(), g_heldFrame.Get());
             return;

--- a/src/resources/d3d11_api.cpp
+++ b/src/resources/d3d11_api.cpp
@@ -21,6 +21,7 @@
 #include "d3d11_text_overlay.hpp"
 #include "mg1_display_scaling.hpp"
 #include "mgs2_crossfade.hpp"
+#include "mgs3_crossfade_capture.hpp"
 #include "mgs_smaa.hpp"
 #include "depth_of_field.hpp"
 #include "mgs3_film_grain.hpp"
@@ -56,33 +57,51 @@ namespace
         return g_GameVars.DG_LastWhich() >= 0 && g_GameVars.DG_UnDrawFrameCount() <= kMaxHeldRun;
     }
 
-    // A crossfade draws the scene twice in one frame and the second pass misses the glow/grade
-    // build. Gated to cutscenes - a count change during gameplay is just scenery coming into view.
-    bool IsDoubleRenderedFrame(uint32_t shadowSets)
+    // The MGS3 crossfade teardown can present one ungraded frame; it shows up as the same shadow
+    // targets rebinding at exactly double their steady rate. Only consulted inside the short
+    // window the crossfade Die hook arms, so scenery changes elsewhere can never trip it.
+    bool IsDoubleRenderedFrame(bool releaseWindow)
     {
-        static uint32_t history[4] {};
-        static size_t head = 0;
+        static std::vector<std::pair<const void*, uint32_t>> baseline;
+        static int steady = 0;
         static bool firedLast = false;
 
-        const uint32_t prev = history[(head + std::size(history) - 1) % std::size(history)];
-        bool steady = prev >= 2;
-        for (const uint32_t s : history)
+        std::vector<std::pair<const void*, uint32_t>> now;
+        SceneDepth::GetShadowPasses(now);
+
+        const bool sameTargets = now.size() == baseline.size() && !now.empty() &&
+            std::equal(now.begin(), now.end(), baseline.begin(),
+                [](const auto& a, const auto& b) { return a.first == b.first; });
+
+        if (sameTargets && std::equal(now.begin(), now.end(), baseline.begin(),
+                [](const auto& a, const auto& b) { return a.second == b.second; }))
         {
-            steady = steady && s == prev;
+            steady++;
+            firedLast = false;
+            return false;
         }
 
-        const bool doubled = !firedLast && steady && shadowSets == prev * 2;
-        history[head] = shadowSets;
-        head = (head + 1) % std::size(history);
-        firedLast = doubled;
+        const bool doubled = sameTargets && !firedLast && steady >= 3 && releaseWindow &&
+            std::equal(now.begin(), now.end(), baseline.begin(),
+                [](const auto& a, const auto& b) { return a.second == b.second * 2; });
 
-        return doubled && g_GameVars.InScriptedSequence();
+        if (doubled)
+        {
+            firedLast = true;   // hold the duplicate, keep the baseline for the frames after it
+            return true;
+        }
+
+        baseline = now;
+        steady = 0;
+        firedLast = false;
+        return false;
     }
 
     void HoldPreviousFrame(IDXGISwapChain* swap)
     {
-        // Consume the count every present, before any bail-out, or it accrues into a false double.
-        const bool doubleRendered = IsDoubleRenderedFrame(SceneDepth::ReadAndResetShadowSetCount());
+        // Consume the passes every present, before any bail-out, or they accrue into a false double.
+        SceneDepth::ReadAndResetShadowSetCount();
+        const bool doubleRendered = IsDoubleRenderedFrame(MGS3_CrossfadeCapture::ReleaseWindowTick());
 
         auto* device = g_D3D11Hooks.d3dDevice.Get();
         auto* context = g_D3D11Hooks.d3dDeviceContext.Get();

--- a/src/resources/gamevars.cpp
+++ b/src/resources/gamevars.cpp
@@ -38,6 +38,13 @@ void GameVars::Initialize()
         p_GV_PauseLevel= reinterpret_cast<int*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "8B 05 ?? ?? ?? ?? A8 ?? 74 ?? A8 ?? 75", "MGS2: p_GV_PauseLevel") + 2));
         MGS2_LinkVarBuf::linkvarbuf = reinterpret_cast<uintptr_t*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "48 8B 0D ?? ?? ?? ?? 89 81 ?? ?? ?? ?? 48 8B CB", "MGS2: LinkVarBuf") + 3));
         p_DG_Clock = reinterpret_cast<int*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "2B 0D ?? ?? ?? ?? E8", "MGS2: DG_Clock") + 2));
+
+        // system/libdg/frame.cpp -> DG_StartFrame() loads both globals before its undraw test.
+        if (uint8_t* DG_StartFrame = Memory::PatternScan(baseModule, "48 89 5C 24 ?? 57 48 83 EC ?? 48 8B 0D ?? ?? ?? ?? BF 01 00 00 00 8B 05 ?? ?? ?? ?? 8B DF 2B 1D ?? ?? ?? ?? 89 1D ?? ?? ?? ?? 48 85 C9", "MGS2: DG_StartFrame"))
+        {
+            p_DG_UnDrawFrameCount64 = reinterpret_cast<int64_t*>(Memory::GetRipRelativeAddress(DG_StartFrame + 0x0A, 3, 7));
+            p_DG_LastWhich = reinterpret_cast<int*>(Memory::GetRipRelativeAddress(DG_StartFrame + 0x16, 2, 6));
+        }
         p_DG_Chanls = reinterpret_cast<DG_CHANL*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 8B CB", "MGS2: DG_Chanls") + 3));
         p_GM_CurrentStageMap = reinterpret_cast<int32_t*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "8B 1D ?? ?? ?? ?? E8 ?? ?? ?? ?? 8B F8", "MGS2: GM_CurrentStageMap") + 2));
 
@@ -55,6 +62,9 @@ void GameVars::Initialize()
         spdlog::info("GameVars: linkvarbuf address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)MGS2_LinkVarBuf::linkvarbuf - (uintptr_t)baseModule);
         spdlog::info("GameVars: scriptedSequenceFlag address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)scriptedSequenceFlag - (uintptr_t)baseModule);
         spdlog::info("GameVars: DG_Clock address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)p_DG_Clock - (uintptr_t)baseModule);
+        spdlog::info("GameVars: DG_LastWhich address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)p_DG_LastWhich - (uintptr_t)baseModule);
+        spdlog::info("GameVars: DG_UnDrawFrameCount address is {:s}+{:X}", sExeName.c_str(),
+            (p_DG_UnDrawFrameCount64 ? (uintptr_t)p_DG_UnDrawFrameCount64 : (uintptr_t)p_DG_UnDrawFrameCount32) - (uintptr_t)baseModule);
         spdlog::info("GameVars: DG_Chanls address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)p_DG_Chanls - (uintptr_t)baseModule);
         spdlog::info("GameVars: GM_CurrentStageMap address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)p_GM_CurrentStageMap - (uintptr_t)baseModule);
         
@@ -83,6 +93,13 @@ void GameVars::Initialize()
         p_GM_MenuStatus = reinterpret_cast<int*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "0B 05 ?? ?? ?? ?? A8 ?? 74 ?? 66 23 CF", "MGS3: p_GM_MenuStatus") + 2));
         p_DG_Clock = reinterpret_cast<int*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "2B 3D ?? ?? ?? ?? 89 3D", "MGS3: DG_Clock") + 2));
 
+        // system/libdg/frame.cpp -> DG_StartFrame() loads both globals before its undraw test.
+        if (uint8_t* DG_StartFrame = Memory::PatternScan(baseModule, "48 89 5C 24 ?? 57 48 83 EC ?? 8B 0D ?? ?? ?? ?? BB 01 00 00 00 8B 05 ?? ?? ?? ?? 8B FB 2B 3D ?? ?? ?? ?? 89 3D ?? ?? ?? ?? 85 C9", "MGS3: DG_StartFrame"))
+        {
+            p_DG_UnDrawFrameCount32 = reinterpret_cast<int32_t*>(Memory::GetRipRelativeAddress(DG_StartFrame + 0x0A, 2, 6));
+            p_DG_LastWhich = reinterpret_cast<int*>(Memory::GetRipRelativeAddress(DG_StartFrame + 0x15, 2, 6));
+        }
+
         spdlog::info("GameVars: cutsceneFlag address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)cutsceneFlag - (uintptr_t)baseModule);
         spdlog::info("GameVars: scriptedSequenceFlag address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)scriptedSequenceFlag - (uintptr_t)baseModule);
         spdlog::info("GameVars: actorWaitValue address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)actorWaitValue - (uintptr_t)baseModule);
@@ -94,7 +111,10 @@ void GameVars::Initialize()
         spdlog::info("GameVars: GM_GameStatus address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)GM_GameStatus - (uintptr_t)baseModule);
         spdlog::info("GameVars: GM_MenuStatus address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)p_GM_MenuStatus - (uintptr_t)baseModule);
         spdlog::info("GameVars: DG_Clock address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)p_DG_Clock - (uintptr_t)baseModule);
-        
+        spdlog::info("GameVars: DG_LastWhich address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)p_DG_LastWhich - (uintptr_t)baseModule);
+        spdlog::info("GameVars: DG_UnDrawFrameCount address is {:s}+{:X}", sExeName.c_str(),
+            (p_DG_UnDrawFrameCount64 ? (uintptr_t)p_DG_UnDrawFrameCount64 : (uintptr_t)p_DG_UnDrawFrameCount32) - (uintptr_t)baseModule);
+
         if (uint8_t* LevelTransitionResult = Memory::PatternScan(baseModule, "89 5F ?? E9 ?? ?? ?? ?? 39 1D", "GameVars: Level Transition"))
         {
             static SafetyHookMid levelTransitionMidHook {};
@@ -495,4 +515,27 @@ int& GameVars::DG_Clock() const
         return dummyDG_Clock;
     }
     return *p_DG_Clock;
+}
+
+int& GameVars::DG_LastWhich() const
+{
+    static int dummyDG_LastWhich = -1; // -1 so a failed scan never holds.
+    if (p_DG_LastWhich == nullptr)
+    {
+        return dummyDG_LastWhich;
+    }
+    return *p_DG_LastWhich;
+}
+
+int64_t GameVars::DG_UnDrawFrameCount() const
+{
+    if (p_DG_UnDrawFrameCount64 != nullptr)
+    {
+        return *p_DG_UnDrawFrameCount64;
+    }
+    if (p_DG_UnDrawFrameCount32 != nullptr)
+    {
+        return *p_DG_UnDrawFrameCount32;
+    }
+    return 0;
 }

--- a/src/resources/gamevars.cpp
+++ b/src/resources/gamevars.cpp
@@ -40,11 +40,8 @@ void GameVars::Initialize()
         p_DG_Clock = reinterpret_cast<int*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "2B 0D ?? ?? ?? ?? E8", "MGS2: DG_Clock") + 2));
 
         // system/libdg/frame.cpp -> DG_StartFrame() loads both globals before its undraw test.
-        if (uint8_t* DG_StartFrame = Memory::PatternScan(baseModule, "48 89 5C 24 ?? 57 48 83 EC ?? 48 8B 0D ?? ?? ?? ?? BF 01 00 00 00 8B 05 ?? ?? ?? ?? 8B DF 2B 1D ?? ?? ?? ?? 89 1D ?? ?? ?? ?? 48 85 C9", "MGS2: DG_StartFrame"))
-        {
-            p_DG_UnDrawFrameCount64 = reinterpret_cast<int64_t*>(Memory::GetRipRelativeAddress(DG_StartFrame + 0x0A, 3, 7));
-            p_DG_LastWhich = reinterpret_cast<int*>(Memory::GetRipRelativeAddress(DG_StartFrame + 0x16, 2, 6));
-        }
+            p_DG_UnDrawFrameCount64 = reinterpret_cast<int64_t*>(Memory::GetRipRelativeAddress(Memory::PatternScan(baseModule, "48 8B 0D ?? ?? ?? ?? BF", "MGS2: DG_UnDrawFrameCount64"), 3, 7));
+            p_DG_LastWhich = reinterpret_cast<int*>(Memory::GetRipRelativeAddress(Memory::PatternScan(baseModule, "8B 05 ?? ?? ?? ?? 8B DF", "MGS2: DG_LastWhich"), 2, 6));
         p_DG_Chanls = reinterpret_cast<DG_CHANL*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 8B CB", "MGS2: DG_Chanls") + 3));
         p_GM_CurrentStageMap = reinterpret_cast<int32_t*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "8B 1D ?? ?? ?? ?? E8 ?? ?? ?? ?? 8B F8", "MGS2: GM_CurrentStageMap") + 2));
 

--- a/src/resources/gamevars.cpp
+++ b/src/resources/gamevars.cpp
@@ -94,11 +94,8 @@ void GameVars::Initialize()
         p_DG_Clock = reinterpret_cast<int*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "2B 3D ?? ?? ?? ?? 89 3D", "MGS3: DG_Clock") + 2));
 
         // system/libdg/frame.cpp -> DG_StartFrame() loads both globals before its undraw test.
-        if (uint8_t* DG_StartFrame = Memory::PatternScan(baseModule, "48 89 5C 24 ?? 57 48 83 EC ?? 8B 0D ?? ?? ?? ?? BB 01 00 00 00 8B 05 ?? ?? ?? ?? 8B FB 2B 3D ?? ?? ?? ?? 89 3D ?? ?? ?? ?? 85 C9", "MGS3: DG_StartFrame"))
-        {
-            p_DG_UnDrawFrameCount32 = reinterpret_cast<int32_t*>(Memory::GetRipRelativeAddress(DG_StartFrame + 0x0A, 2, 6));
-            p_DG_LastWhich = reinterpret_cast<int*>(Memory::GetRipRelativeAddress(DG_StartFrame + 0x15, 2, 6));
-        }
+        p_DG_UnDrawFrameCount32 = reinterpret_cast<int32_t*>(Memory::GetRipRelativeAddress(Memory::PatternScan(baseModule, "8B 0D ?? ?? ?? ?? BB ?? ?? ?? ?? 8B 05", "MGS3: DG_UnDrawFrameCount32"), 2, 6));
+        p_DG_LastWhich = reinterpret_cast<int*>(Memory::GetRipRelativeAddress(Memory::PatternScan(baseModule, "8B 05 ?? ?? ?? ?? 8B FB", "MGS3: DG_LastWhich"), 2, 6));
 
         spdlog::info("GameVars: cutsceneFlag address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)cutsceneFlag - (uintptr_t)baseModule);
         spdlog::info("GameVars: scriptedSequenceFlag address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)scriptedSequenceFlag - (uintptr_t)baseModule);

--- a/src/resources/gamevars.hpp
+++ b/src/resources/gamevars.hpp
@@ -128,6 +128,8 @@ public:
     [[nodiscard]] int& GV_PauseLevel() const;
     [[nodiscard]] int& GM_MenuStatus() const;
     [[nodiscard]] int& DG_Clock() const;
+    [[nodiscard]] int& DG_LastWhich() const; // >= 0 when DG_StartFrame skipped drawing the frame.
+    [[nodiscard]] int64_t DG_UnDrawFrameCount() const; // Frames still scheduled undrawn.
 
     [[nodiscard]] static constexpr uint32_t GV_StrCode(const char* inputString)
     {
@@ -168,6 +170,9 @@ private:
     int* GM_VRStatus = nullptr;
     int* p_GV_PauseLevel = nullptr;
     int* p_DG_Clock = nullptr;
+    int* p_DG_LastWhich = nullptr;
+    int64_t* p_DG_UnDrawFrameCount64 = nullptr; // MGS2 declares it long64, MGS3 long
+    int32_t* p_DG_UnDrawFrameCount32 = nullptr;
     DG_CHANL* p_DG_Chanls = nullptr;
 
     int32_t* p_GM_CurrentStageMap = nullptr;

--- a/src/resources/scene_depth.cpp
+++ b/src/resources/scene_depth.cpp
@@ -137,6 +137,13 @@ namespace
 
     std::atomic<uint32_t> g_shadowSetCounter = 0;
 
+    // Diagnostic: are the doubled passes the same targets twice, or twice as many casters?
+    struct ShadowPass { const void* tex; uint32_t dim; };
+    ShadowPass g_shadowPasses[64] {};
+    std::atomic<uint32_t> g_shadowPassCount = 0;
+    ShadowPass g_lastPasses[64] {};
+    uint32_t g_lastPassCount = 0;
+
     // ---- Late-pass depth propagation (MGS2) -----------------------------------------------------
     // With MSAA the game renders the scene into an MSAA depth buffer, then binds a separate never-written
     // non-MSAA depth for the late overlay pass, so overlay prims z-test against an empty buffer (and our
@@ -278,6 +285,11 @@ namespace
                 if (d.Width == d.Height && d.Width >= 256)
                 {
                     g_shadowSetCounter.fetch_add(1, std::memory_order_relaxed);
+                    const uint32_t slot = g_shadowPassCount.fetch_add(1, std::memory_order_relaxed);
+                    if (slot < std::size(g_shadowPasses))
+                    {
+                        g_shadowPasses[slot] = { tex.Get(), d.Width };
+                    }
                 }
             }
         }
@@ -432,7 +444,23 @@ void SceneDepth::SetOverlayEndCallback(EndOf3DCallback cb)
 
 uint32_t SceneDepth::ReadAndResetShadowSetCount()
 {
+    const uint32_t n = g_shadowPassCount.exchange(0, std::memory_order_relaxed);
+    g_lastPassCount = (std::min)(n, static_cast<uint32_t>(std::size(g_shadowPasses)));
+    memcpy(g_lastPasses, g_shadowPasses, sizeof(g_lastPasses));
     return g_shadowSetCounter.exchange(0, std::memory_order_relaxed);
+}
+
+void SceneDepth::GetShadowPasses(std::vector<std::pair<const void*, uint32_t>>& out)
+{
+    out.clear();
+    for (uint32_t i = 0; i < g_lastPassCount; i++)
+    {
+        auto it = std::find_if(out.begin(), out.end(),
+            [&](const auto& p) { return p.first == g_lastPasses[i].tex; });
+        if (it == out.end()) out.emplace_back(g_lastPasses[i].tex, 1u);
+        else it->second++;
+    }
+    std::sort(out.begin(), out.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
 }
 
 ID3D11ShaderResourceView* SceneDepth::GetSRV()

--- a/src/resources/scene_depth.cpp
+++ b/src/resources/scene_depth.cpp
@@ -265,8 +265,7 @@ namespace
         ID3D11RenderTargetView* const* rtvs,
         ID3D11DepthStencilView* dsv)
     {
-        // Count shadow passes (square depth-attached targets) - a frame-skip catch-up
-        // renders the scene twice in one present, doubling this per frame.
+        // Shadow passes are the square depth-attached targets.
         if (numViews > 0 && rtvs && rtvs[0] && dsv)
         {
             ComPtr<ID3D11Resource> res;

--- a/src/resources/scene_depth.hpp
+++ b/src/resources/scene_depth.hpp
@@ -37,6 +37,9 @@ namespace SceneDepth
     // Per-present shadow pass count; doubles when a crossfade draws the scene twice.
     uint32_t ReadAndResetShadowSetCount();
 
+    // Last present's shadow targets with their bind counts, sorted by target.
+    void GetShadowPasses(std::vector<std::pair<const void*, uint32_t>>& out);
+
     // Fires at the end of the 3D pass (after the scene, before UI). Gives the scene colour RT to draw
     // into and the depth SRV for occlusion.
     using EndOf3DCallback = void(*)(ID3D11RenderTargetView* sceneColor, ID3D11ShaderResourceView* depth);

--- a/src/resources/scene_depth.hpp
+++ b/src/resources/scene_depth.hpp
@@ -34,8 +34,7 @@ namespace SceneDepth
     // points in the frame where depth is no longer bound.
     ID3D11ShaderResourceView* CaptureSceneDepth();
 
-    // Per-frame count of shadow target sets; doubles when a frame-skip catch-up renders
-    // the scene twice in one present.
+    // Per-present shadow pass count; doubles when a crossfade draws the scene twice.
     uint32_t ReadAndResetShadowSetCount();
 
     // Fires at the end of the 3D pass (after the scene, before UI). Gives the scene colour RT to draw


### PR DESCRIPTION
MGS2 fix is sound, MGS3 runs inside the same method causing the issues, identifies a duplicate draw to copy the previous frame as new one will not be complete when requested which only MGS3 needs (the cigar crossfade flicker).