### PR TITLE
MGS2: fix the glass packet writing past its buffer

### DIFF
--- a/MGSHDFix.vcxproj
+++ b/MGSHDFix.vcxproj
@@ -13,6 +13,7 @@
     <ClCompile Include="src\features\mgs_smaa.cpp" />
     <ClCompile Include="src\fixes\color_correction.cpp" />
     <ClCompile Include="src\features\mgs2_vamp_punch_fix.cpp" />
+    <ClCompile Include="src\fixes\mgs2_glass_dmapack_overflow.cpp" />
     <ClCompile Include="src\fixes\mgs2_newscrconcentrateblur.cpp" />
     <ClCompile Include="src\fixes\mgs2_enhanced_demos.cpp" />
     <ClCompile Include="src\resources\d3d11_text_overlay.cpp" />
@@ -147,6 +148,7 @@
   <ItemGroup>
     <ClInclude Include="src\fixes\screenspace_fixes.hpp" />
     <ClInclude Include="src\fixes\mgs2_tanker_snake_snap.hpp" />
+    <ClInclude Include="src\fixes\mgs2_glass_dmapack_overflow.hpp" />
     <ClInclude Include="src\resources\game_strings.hpp" />
     <ClInclude Include="src\fixes\caption_replacements.hpp" />
     <ClInclude Include="src\resources\mgs3_status_flags.hpp" />

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -48,6 +48,7 @@
 #include "mgs2_railgun_beam.hpp"
 #include "mgs2_demo_blur.hpp"
 #include "mgs2_tanker_snake_snap.hpp"
+#include "mgs2_glass_dmapack_overflow.hpp"
 #include "cpu_core_limit.hpp"
 #include "aiming_after_equip.hpp"
 #include "line_scaling.hpp"
@@ -533,6 +534,7 @@ static void InitializeSubsystems()
 
     if (eGameType & MGS2)
     {
+        INITIALIZE(MGS2_GlassDmapackOverflow::Initialize());
         INITIALIZE(g_MGS2Sunglasses.Initialize());
         INITIALIZE(MGS2_RestoreDogtags::Initialize());
         INITIALIZE(MGS2_RestoreOriginalDifficulty::Apply());

--- a/src/fixes/mgs2_glass_dmapack_overflow.cpp
+++ b/src/fixes/mgs2_glass_dmapack_overflow.cpp
@@ -1,0 +1,40 @@
+#include "stdafx.h"
+#include "mgs2_glass_dmapack_overflow.hpp"
+
+#include "common.hpp"
+#include "logging.hpp"
+
+// MC added a fourth setter to brk_gls_ini.c's packet chain without growing the buffer, so the
+// terminator lands one byte past it, on the next heap block's prev link.
+namespace
+{
+    constexpr uint8_t kOriginalSize = 0x40;
+    constexpr uint8_t kPatchedSize = 0x50;      // 0x48 would do; keep the block 16-aligned
+}
+
+void MGS2_GlassDmapackOverflow::Initialize()
+{
+    if (!(eGameType & MGS2))
+    {
+        return;
+    }
+
+    // The store to +0x2a0 is work->packet, which is what tells this malloc from any other.
+    uint8_t* address = Memory::PatternScan(baseModule,
+        "B9 40 00 00 00 E8 ?? ?? ?? ?? 48 89 83 A0 02 00 00",
+        "MGS 2: Glass Packet Overflow | brk_gls_ini.c -> InitDmapack()");
+    if (address == nullptr)
+    {
+        return;
+    }
+
+    if (address[1] != kOriginalSize)
+    {
+        spdlog::warn("MGS 2: Glass Packet Overflow: buffer is already {:#x}, leaving it alone.",
+            address[1]);
+        return;
+    }
+
+    Memory::PatchBytes(reinterpret_cast<uintptr_t>(address) + 1, "\x50", 1);
+    spdlog::info("MGS 2: Glass Packet Overflow: buffer grown to {:#x} bytes.", kPatchedSize);
+}

--- a/src/fixes/mgs2_glass_dmapack_overflow.hpp
+++ b/src/fixes/mgs2_glass_dmapack_overflow.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace MGS2_GlassDmapackOverflow
+{
+    void Initialize();
+}


### PR DESCRIPTION
MC added DG_SetDmapackViewMapping to brk_gls_ini.c's setter chain in 2.0 and left the buffer at sizeof(int)*16 freeing that block then walks over the edge mangling beyond it