### PR TITLE
MGS2/MGS3: land in-game camera photos in the Steam screenshot library

### DIFF
--- a/ConfigTool/tab_data.cpp
+++ b/ConfigTool/tab_data.cpp
@@ -231,6 +231,9 @@ const std::vector<std::pair<wxString, std::vector<Field>>> kTabs = {
         { (MGS2), ConfigKeys::MGS2_FixDamageType_Section, ConfigKeys::MGS2_FixDamageType_Setting, ConfigKeys::MGS2_FixDamageType_Help, ConfigKeys::MGS2_FixDamageType_Tooltip,
             std::nullopt, false, Field::Bool, false},
 
+        { (MGS2 | MGS3), ConfigKeys::PhotoCamera_Section, ConfigKeys::PhotoCamera_Setting, ConfigKeys::PhotoCamera_Help, ConfigKeys::PhotoCamera_Tooltip,
+          std::nullopt, false, Field::Bool, false },
+
 
             {(MGS2), ConfigKeys::MGS2_Lifebar_Name_Custom_Section, "", "", "", std::nullopt, false, Field::Spacer },
 

--- a/ConfigTool/tab_data.cpp
+++ b/ConfigTool/tab_data.cpp
@@ -232,7 +232,7 @@ const std::vector<std::pair<wxString, std::vector<Field>>> kTabs = {
             std::nullopt, false, Field::Bool, false},
 
         { (MGS2 | MGS3), ConfigKeys::PhotoCamera_Section, ConfigKeys::PhotoCamera_Setting, ConfigKeys::PhotoCamera_Help, ConfigKeys::PhotoCamera_Tooltip,
-          std::nullopt, false, Field::Bool, false },
+          std::nullopt, false, Field::Bool, true},
 
 
             {(MGS2), ConfigKeys::MGS2_Lifebar_Name_Custom_Section, "", "", "", std::nullopt, false, Field::Spacer },

--- a/MGSHDFix.vcxproj
+++ b/MGSHDFix.vcxproj
@@ -83,6 +83,7 @@
     <ClCompile Include="src\fixes\mgs2_railgun_beam.cpp" />
     <ClCompile Include="src\features\keep_aiming_after_firing.cpp" />
     <ClCompile Include="src\fixes\pressure_inputs.cpp" />
+    <ClCompile Include="src\fixes\photo_camera.cpp" />
     <ClCompile Include="src\features\mgs2_sunglasses.cpp" />
     <ClCompile Include="src\resources\config.cpp" />
     <ClCompile Include="external\safetyhook\src\allocator.cpp">
@@ -232,6 +233,7 @@
     <ClInclude Include="src\fixes\mgs2_autopacket.hpp" />
     <ClInclude Include="src\features\keep_aiming_after_firing.hpp" />
     <ClInclude Include="src\fixes\pressure_inputs.hpp" />
+    <ClInclude Include="src\fixes\photo_camera.hpp" />
     <ClInclude Include="src\features\mgs2_sunglasses.hpp" />
     <ClInclude Include="src\resources\config.hpp" />
     <ClInclude Include="external\safetyhook\include\safetyhook.hpp" />

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -99,6 +99,7 @@
 #include "mgs2_restore_elevator_glitch.hpp"
 #include "mgs2_shimmer.hpp"
 #include "mgs2_crossfade.hpp"
+#include "photo_camera.hpp"
 #include "mgs2_newscrconcentrateblur.hpp"
 #include "mgs2_enhanced_demos.hpp"
 #include "playtime_fixes.hpp"
@@ -478,7 +479,7 @@ void afterPresent()
     if (eGameType & (MGS2|MGS3))
     {
         CaptionReplacements::InitializeCaptionOverrides();
-
+        PhotoCamera::Initialize();
     }
 
     if (eGameType & MGS2)

--- a/src/fixes/photo_camera.cpp
+++ b/src/fixes/photo_camera.cpp
@@ -8,7 +8,8 @@
 #pragma warning(push)
 #pragma warning(disable:4828)
 #include "isteamscreenshots.h"
-#include "isteamremotestorage.h"
+#include "steam_api.h"
+#include "isteamscreenshots.h"
 #pragma warning(pop)
 
 // The camera freezes the screen for its capture, so the next present still shows exactly the

--- a/src/fixes/photo_camera.cpp
+++ b/src/fixes/photo_camera.cpp
@@ -1,0 +1,116 @@
+#include "stdafx.h"
+#include "photo_camera.hpp"
+
+#include "common.hpp"
+#include "logging.hpp"
+#include "d3d11_api.hpp"
+
+#pragma warning(push)
+#pragma warning(disable:4828)
+#include "steam_api.h"
+#include "isteamscreenshots.h"
+#pragma warning(pop)
+
+// The camera freezes the screen for its capture, so the next present still shows exactly the
+// photo frame - grab the backbuffer there and hand it to Steam alongside the game's own
+// save-file capture.
+namespace
+{
+    std::atomic<bool> gPending = false;
+    SafetyHookMid gSnapHook {};
+
+    void Capture(IDXGISwapChain* swap)
+    {
+        ComPtr<ID3D11Texture2D> backbuffer;
+        swap->GetBuffer(0, __uuidof(ID3D11Texture2D), reinterpret_cast<void**>(backbuffer.GetAddressOf()));
+        if (!backbuffer || !g_D3D11Hooks.d3dDevice || !g_D3D11Hooks.d3dDeviceContext)
+        {
+            return;
+        }
+        D3D11_TEXTURE2D_DESC desc {};
+        backbuffer->GetDesc(&desc);
+        const bool bgra = desc.Format == DXGI_FORMAT_B8G8R8A8_UNORM || desc.Format == DXGI_FORMAT_B8G8R8A8_UNORM_SRGB;
+        if (!bgra && desc.Format != DXGI_FORMAT_R8G8B8A8_UNORM && desc.Format != DXGI_FORMAT_R8G8B8A8_UNORM_SRGB)
+        {
+            spdlog::warn("Photo Camera - unsupported backbuffer format {}.", static_cast<int>(desc.Format));
+            return;
+        }
+
+        desc.Usage = D3D11_USAGE_STAGING;
+        desc.BindFlags = 0;
+        desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+        desc.MiscFlags = 0;
+        desc.MipLevels = 1;
+        desc.ArraySize = 1;
+        desc.SampleDesc = { 1, 0 };
+        ComPtr<ID3D11Texture2D> staging;
+        g_D3D11Hooks.d3dDevice->CreateTexture2D(&desc, nullptr, staging.GetAddressOf());
+        if (!staging)
+        {
+            return;
+        }
+        ID3D11DeviceContext* ctx = g_D3D11Hooks.d3dDeviceContext.Get();
+        ctx->CopyResource(staging.Get(), backbuffer.Get());
+
+        // The stall is fine: the game itself is holding the frame for its own capture.
+        D3D11_MAPPED_SUBRESOURCE mapped {};
+        if (FAILED(ctx->Map(staging.Get(), 0, D3D11_MAP_READ, 0, &mapped)))
+        {
+            return;
+        }
+        std::vector<uint8_t> rgb(static_cast<size_t>(desc.Width) * desc.Height * 3);
+        for (UINT y = 0; y < desc.Height; ++y)
+        {
+            const uint8_t* src = static_cast<const uint8_t*>(mapped.pData) + static_cast<size_t>(y) * mapped.RowPitch;
+            uint8_t* dst = rgb.data() + static_cast<size_t>(y) * desc.Width * 3;
+            for (UINT x = 0; x < desc.Width; ++x, src += 4, dst += 3)
+            {
+                dst[0] = src[bgra ? 2 : 0];
+                dst[1] = src[1];
+                dst[2] = src[bgra ? 0 : 2];
+            }
+        }
+        ctx->Unmap(staging.Get(), 0);
+
+        if (ISteamScreenshots* shots = SteamScreenshots())
+        {
+            shots->WriteScreenshot(rgb.data(), static_cast<uint32>(rgb.size()), desc.Width, desc.Height);
+        }
+    }
+}
+
+void PhotoCamera::OnPresent(IDXGISwapChain* swap)
+{
+    if (gPending.exchange(false, std::memory_order_relaxed))
+    {
+        Capture(swap);
+    }
+}
+
+void PhotoCamera::Initialize()
+{
+    if (!bEnabled || !(eGameType & (MGS2 | MGS3)))
+    {
+        return;
+    }
+
+    // Both games freeze the screen for the capture (DG_UnDrawFrameCount parked at its max),
+    // so that store is the shutter moment: once per photo, every camera mode.
+    uint8_t* address = eGameType & MGS2
+        ? Memory::PatternScan(baseModule,
+            "8B 0D ?? ?? ?? ?? 44 89 35 ?? ?? ?? ?? 89 4F 5C 44 89 35 ?? ?? ?? ?? 48 C7 05 ?? ?? ?? ?? 00 00 FF 7F",
+            "MGS 2: Photo Camera - Capture Start | skoba\\equip\\capture.c -> NewCaptureStart()")
+        : Memory::PatternScan(baseModule,
+            "8B 05 ?? ?? ?? ?? 8B C8 48 8B 5C 24 ?? F7 D1 83 E1 2C 83 C8 2C 89 05 ?? ?? ?? ?? "
+            "48 8B 47 50 89 88 ?? ?? ?? ?? C7 05 ?? ?? ?? ?? FF FF 00 00",
+            "MGS 3: Photo Camera - Capture Start | mc_photo.c photo actor");
+    if (address == nullptr)
+    {
+        return;
+    }
+    gSnapHook = safetyhook::create_mid(address, [](SafetyHookContext&)
+    {
+        gPending.store(true, std::memory_order_relaxed);
+    });
+    LOG_HOOK(gSnapHook, "Photo Camera - Capture Start")
+}

--- a/src/fixes/photo_camera.cpp
+++ b/src/fixes/photo_camera.cpp
@@ -8,6 +8,7 @@
 #pragma warning(push)
 #pragma warning(disable:4828)
 #include "isteamscreenshots.h"
+#include "isteamremotestorage.h"
 #pragma warning(pop)
 
 // The camera freezes the screen for its capture, so the next present still shows exactly the

--- a/src/fixes/photo_camera.cpp
+++ b/src/fixes/photo_camera.cpp
@@ -1,6 +1,6 @@
 #include "stdafx.h"
 #include "photo_camera.hpp"
-
+#include "steamworks_api.hpp"
 #include "common.hpp"
 #include "logging.hpp"
 #include "d3d11_api.hpp"

--- a/src/fixes/photo_camera.cpp
+++ b/src/fixes/photo_camera.cpp
@@ -7,7 +7,6 @@
 
 #pragma warning(push)
 #pragma warning(disable:4828)
-#include "isteamscreenshots.h"
 #include "steam_api.h"
 #include "isteamscreenshots.h"
 #pragma warning(pop)

--- a/src/fixes/photo_camera.cpp
+++ b/src/fixes/photo_camera.cpp
@@ -7,7 +7,6 @@
 
 #pragma warning(push)
 #pragma warning(disable:4828)
-#include "steam_api.h"
 #include "isteamscreenshots.h"
 #pragma warning(pop)
 
@@ -93,16 +92,20 @@ void PhotoCamera::Initialize()
     {
         return;
     }
+    if (!g_SteamAPI.bInitialized)
+    {
+        spdlog::info("MGS 2: Photo Camera: SteamAPI not initialized. Skipping setup.");
+        return;
+    }
 
     // Both games freeze the screen for the capture (DG_UnDrawFrameCount parked at its max),
     // so that store is the shutter moment: once per photo, every camera mode.
     uint8_t* address = eGameType & MGS2
         ? Memory::PatternScan(baseModule,
-            "8B 0D ?? ?? ?? ?? 44 89 35 ?? ?? ?? ?? 89 4F 5C 44 89 35 ?? ?? ?? ?? 48 C7 05 ?? ?? ?? ?? 00 00 FF 7F",
+            "8B 0D ?? ?? ?? ?? 44 89 35 ?? ?? ?? ?? 89 4F",
             "MGS 2: Photo Camera - Capture Start | skoba\\equip\\capture.c -> NewCaptureStart()")
         : Memory::PatternScan(baseModule,
-            "8B 05 ?? ?? ?? ?? 8B C8 48 8B 5C 24 ?? F7 D1 83 E1 2C 83 C8 2C 89 05 ?? ?? ?? ?? "
-            "48 8B 47 50 89 88 ?? ?? ?? ?? C7 05 ?? ?? ?? ?? FF FF 00 00",
+            "8B 05 ?? ?? ?? ?? 8B C8 48 8B 5C 24",
             "MGS 3: Photo Camera - Capture Start | mc_photo.c photo actor");
     if (address == nullptr)
     {

--- a/src/fixes/photo_camera.hpp
+++ b/src/fixes/photo_camera.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+struct IDXGISwapChain;
+
+// The in-game camera's shutter also lands a full-resolution shot in the Steam screenshot
+// library, instead of only the tiny save-file photo the ports inherited from the PS2.
+namespace PhotoCamera
+{
+    inline bool bEnabled = false;
+
+    void Initialize();
+    void OnPresent(IDXGISwapChain* swap);
+}

--- a/src/resources/config.cpp
+++ b/src/resources/config.cpp
@@ -9,6 +9,7 @@
 #include "aiming_after_equip.hpp"
 #include "aiming_full_tilt.hpp"
 #include "pressure_inputs.hpp"
+#include "photo_camera.hpp"
 #include "mgs2_blood_stains.hpp"
 #include "mgs2_scope_warp.hpp"
 #include "mgs2_water_effects.hpp"
@@ -488,6 +489,9 @@ void Config::Read()
 
     ConfigHelper::getValue(ini, ConfigKeys::DisableTextureFiltering_Section, ConfigKeys::DisableTextureFiltering_Setting, bDisableTextureFiltering);
     LOG_CONFIG(ConfigKeys::DisableTextureFiltering_Section, ConfigKeys::DisableTextureFiltering_Setting, bDisableTextureFiltering);
+
+    ConfigHelper::getValue(ini, ConfigKeys::PhotoCamera_Section, ConfigKeys::PhotoCamera_Setting, PhotoCamera::bEnabled);
+    LOG_CONFIG(ConfigKeys::PhotoCamera_Section, ConfigKeys::PhotoCamera_Setting, PhotoCamera::bEnabled);
 
     ConfigHelper::getValue(ini, ConfigKeys::FramebufferFix_Section, ConfigKeys::FramebufferFix_Setting, CustomResolutionAndBorderless::bFramebufferFix);
     LOG_CONFIG(ConfigKeys::FramebufferFix_Section, ConfigKeys::FramebufferFix_Setting, CustomResolutionAndBorderless::bFramebufferFix);

--- a/src/resources/config_keys.hpp
+++ b/src/resources/config_keys.hpp
@@ -89,6 +89,14 @@ namespace ConfigKeys
     constexpr const char* ColorCorrection_Enabled_Tooltip = "Corrects gamma levels to more closely match the original presentation on a CRT.";
 
 
+    constexpr const char* PhotoCamera_Section = "Various";
+    constexpr const char* PhotoCamera_Setting = "Digital Camera Steam Screenshots";
+    constexpr const char* PhotoCamera_Help = "";
+    constexpr const char* PhotoCamera_Tooltip =
+        "Every photo taken with the in-game camera also lands in your Steam screenshot\n"
+        "library at full resolution, alongside the tiny save-file photo the game keeps\n"
+        "for itself. MGS 2's digital camera and MGS 3's camera, ghosts included.";
+
     constexpr const char* DisableTextureFiltering_Section = "Enhancements and Tweaks";
     constexpr const char* DisableTextureFiltering_Setting = "Nearest Neighbor Texture Filtering";
     constexpr const char* DisableTextureFiltering_Help = "";

--- a/src/resources/d3d11_api.cpp
+++ b/src/resources/d3d11_api.cpp
@@ -21,6 +21,7 @@
 #include "d3d11_text_overlay.hpp"
 #include "mg1_display_scaling.hpp"
 #include "mgs2_crossfade.hpp"
+#include "photo_camera.hpp"
 #include "mgs3_crossfade_capture.hpp"
 #include "mgs_smaa.hpp"
 #include "depth_of_field.hpp"
@@ -306,6 +307,10 @@ ColorCorrection::Draw(pSwapChain);
         if (eGameType & MGS3)
         {
             MGS3FilmGrain::EndPresent();
+        }
+        if (eGameType & (MGS2 | MGS3))
+        {
+            PhotoCamera::OnPresent(pSwapChain);   // before the overlay: the photo is the game frame
         }
         D3D11TextOverlay::Tick(); //keep last.
         g_preMenuFired = false;


### PR DESCRIPTION
A fun little option to actually save the screenshots taken with the game!