### PR TITLE
MGS2/MGS3: bind a key to return to the developer menu

### DIFF
--- a/ConfigTool/tab_data.cpp
+++ b/ConfigTool/tab_data.cpp
@@ -466,6 +466,9 @@ std::nullopt, false, Field::Int, 100, 1, 100},
         { (MGS2|MGS3), ConfigKeys::CycleWireframeMode_Section, ConfigKeys::CycleWireframeMode_Setting, ConfigKeys::CycleWireframeMode_Help, ConfigKeys::CycleWireframeMode_Tooltip,
           std::make_pair(ConfigKeys::MGS2_Restore_VFX_Section, ConfigKeys::MGS2_Restore_VFX_Setting), false, Field::Hotkey, 0, 0, 0, "End"},
 
+        { (MGS2|MGS3), ConfigKeys::DevMenuHotkey_Section, ConfigKeys::DevMenuHotkey_Setting, ConfigKeys::DevMenuHotkey_Help, ConfigKeys::DevMenuHotkey_Tooltip,
+          std::make_pair(ConfigKeys::Debugging_Start_In_Dev_Menu_Section, ConfigKeys::Debugging_Start_In_Dev_Menu_Setting), false, Field::Hotkey, 0, 0, 0, "F8" },
+
         { (MGS3), ConfigKeys::OverrideMouseSensitivity_Section, ConfigKeys::OverrideMouseSensitivity_Setting, ConfigKeys::OverrideMouseSensitivity_Help, ConfigKeys::OverrideMouseSensitivity_Tooltip,
           std::nullopt, false, Field::Bool, false },
 

--- a/src/resources/config.cpp
+++ b/src/resources/config.cpp
@@ -1100,6 +1100,11 @@ void Config::Read()
     ConfigHelper::getValue(ini, ConfigKeys::Debugging_Start_In_Dev_Menu_Section, ConfigKeys::Debugging_Start_In_Dev_Menu_Setting, Shared_Gamefuncs::StartInDebugMode);
     LOG_CONFIG(ConfigKeys::Debugging_Start_In_Dev_Menu_Section, ConfigKeys::Debugging_Start_In_Dev_Menu_Setting, Shared_Gamefuncs::StartInDebugMode);
 
+    if (Shared_Gamefuncs::StartInDebugMode)
+    {
+        InputHandler::GetKeybind(ini, ConfigKeys::DevMenuHotkey_Section, ConfigKeys::DevMenuHotkey_Setting, Shared_Gamefuncs::DevMenuHotkey);
+    }
+
     ConfigHelper::getValue(ini, ConfigKeys::FixIGTLoadingPause_Section, ConfigKeys::FixIGTLoadingPause_Setting, FixPlaytime::bEnabled);
     LOG_CONFIG(ConfigKeys::FixIGTLoadingPause_Section, ConfigKeys::FixIGTLoadingPause_Setting, FixPlaytime::bEnabled);
 

--- a/src/resources/config_keys.hpp
+++ b/src/resources/config_keys.hpp
@@ -865,6 +865,13 @@ namespace ConfigKeys
     constexpr const char* CycleWireframeMode_Help = "";
     constexpr const char* CycleWireframeMode_Tooltip = "Cycle between wireframe rendering modes (available when Rain Width Fix is enabled).";
 
+    constexpr const char* DevMenuHotkey_Section = "Hotkeys";
+    constexpr const char* DevMenuHotkey_Setting = "Return to Developer Menu";
+    constexpr const char* DevMenuHotkey_Help = "";
+    constexpr const char* DevMenuHotkey_Tooltip = "Returns to the developer menu at any time, from anywhere in the game.\n"
+                                                  "\n"
+                                                  "Requires \"Start Game in Developer Menu\" to be enabled.";
+
 
     // Achievements
 

--- a/src/resources/game_funcs.cpp
+++ b/src/resources/game_funcs.cpp
@@ -9,6 +9,7 @@
 #include "gamevars.hpp"
 #include "mgs2_linkvarbuf.hpp"
 #include "mgs3_linkvarbuf.hpp"
+#include "input_handler.hpp"
 /*
 #if defined(RELEASE_BUILD)
 #define RELEASE_CLEARED
@@ -89,7 +90,22 @@ namespace
 
     constexpr unsigned int STRCODE_SCENERIO_GCX = GameVars::GV_StrCode("scenerio");
 
+    // Swap to the select stage under scenerio.gcx and flag a load, the same request the game's own
+    // debug helper issues. Set by whichever game hooked, since the linkvars differ.
+    void (*EnterDeveloperMenu)() = nullptr;
 
+    void RegisterDevMenuHotkey()
+    {
+        if (!Shared_Gamefuncs::DevMenuHotkey || !EnterDeveloperMenu)
+        {
+            return;
+        }
+
+        g_InputHandler.RegisterHotkey(Shared_Gamefuncs::DevMenuHotkey, "Return to Developer Menu", []()
+        {
+            EnterDeveloperMenu();
+        });
+    }
 }
 
 namespace MGS2_GameFuncs
@@ -171,6 +187,23 @@ void MGS2_GameFuncs::HookGameFuncs()
         GM_LoadRequest = reinterpret_cast<int*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "8B 05 ?? ?? ?? ?? A8 10 74 ?? E8", "MGS2: GM_PlayerStatus") + 2));
         spdlog::info("MGS2_GameFuncs: GM_LoadRequest address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)GM_LoadRequest - (uintptr_t)baseModule);
 
+        EnterDeveloperMenu = []()
+        {
+            using namespace Shared_Gamefuncs;
+            using namespace MGS2_LinkVarBuf;
+            using namespace MGS2Stages;
+
+            if (!GM_SetArea || !GCL_ChangeSenerioCode || !GM_LoadRequest)
+            {
+                return;
+            }
+
+            GM_SetArea(GM_SaveArea, SELECT);
+            GCL_ChangeSenerioCode(STRCODE_SCENERIO_GCX);
+            GM_Result = 9999;
+            *GM_LoadRequest = 0x0002 | 0x1;
+        };
+
         MAKE_HOOK_MID(baseModule, "E9 ?? ?? ?? ?? C7 43 ?? 01 00 00 00 E9", "GM_StartDaemon() -> Act() | Set developer menu on startup", {
             static bool startup = true;
             if (!startup)
@@ -178,11 +211,10 @@ void MGS2_GameFuncs::HookGameFuncs()
                 return;
             }
             startup = false;
-            GM_SetArea(GM_SaveArea, SELECT);
-            GCL_ChangeSenerioCode(STRCODE_SCENERIO_GCX);
-            GM_Result = 9999;
-            *GM_LoadRequest = 0x0002 | 0x1;
+            EnterDeveloperMenu();
                       });
+
+        RegisterDevMenuHotkey();
     }
 
 
@@ -261,8 +293,27 @@ void MGS3_Gamefuncs::HookGameFuncs()
         spdlog::info("MGS3_GameFuncs: GCL_ChangeSenerioCode address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)GCL_ChangeSenerioCode - (uintptr_t)baseModule);
 
 
-        GM_LoadRequest = reinterpret_cast<int*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "83 0D ?? ?? ?? ?? ?? B9 ?? ?? ?? ?? E8 ?? ?? ?? ?? B9 ?? ?? ?? ?? 48 83 C4 ?? E9", "MGS3: GM_PlayerStatus") + 2));
+        // or dword ptr [rip+disp32], imm8 - the imm8 makes this 7 bytes, so the displacement is
+        // not the last field and GetRelativeOffset would land a byte low.
+        GM_LoadRequest = reinterpret_cast<int*>(Memory::GetRipRelativeAddress(Memory::PatternScan(baseModule, "83 0D ?? ?? ?? ?? ?? B9 ?? ?? ?? ?? E8 ?? ?? ?? ?? B9 ?? ?? ?? ?? 48 83 C4 ?? E9", "MGS3: GM_PlayerStatus"), 2, 7));
         spdlog::info("MGS3_GameFuncs: GM_LoadRequest address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)GM_LoadRequest - (uintptr_t)baseModule);
+
+        EnterDeveloperMenu = []()
+        {
+            using namespace Shared_Gamefuncs;
+            using namespace MGS3_LinkVarBuf;
+            using namespace MGS3Stages;
+
+            if (!GM_SetArea || !GCL_ChangeSenerioCode || !GM_LoadRequest)
+            {
+                return;
+            }
+
+            GM_SetArea(GM_SaveArea, SELECT);
+            GCL_ChangeSenerioCode(STRCODE_SCENERIO_GCX);
+            GM_Result = 9999;
+            *GM_LoadRequest = 0x3;
+        };
 
         if (uint8_t* Act_addr = Memory::PatternScan(baseModule, "48 83 EC ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 44 24 ?? 48 89 5C 24", "GM_StartDaemon() -> Act() | Set developer menu on startup"))
         {
@@ -277,14 +328,13 @@ void MGS3_Gamefuncs::HookGameFuncs()
                     }
 
                     startup = false;
-                    GM_SetArea(GM_SaveArea, SELECT);
-                    GCL_ChangeSenerioCode(STRCODE_SCENERIO_GCX);
-                    GM_Result = 9999;
-                    *GM_LoadRequest = 0x3;
+                    EnterDeveloperMenu();
                 });
 
             LOG_HOOK(Act_Startup_hook, "GM_StartDaemon() -> Act()+0x406 | Set developer menu on startup");
         }
+
+        RegisterDevMenuHotkey();
     }
 
 

--- a/src/resources/game_funcs.hpp
+++ b/src/resources/game_funcs.hpp
@@ -12,6 +12,7 @@ namespace Shared_Gamefuncs
 {
     void HookFuncs();
     inline bool StartInDebugMode = false;
+    inline int  DevMenuHotkey = 0;
 
 
     using GM_SetArea_t = void(__fastcall*)(int id, const char* dirname);


### PR DESCRIPTION
Adds a "Return to Developer Menu" hotkey under Controls | Hotkeys, defaulting to F8 and dependent on "Start Game in Developer Menu", so it is only read and registered when developer mode is on.

Both games issue the same request, so the jump moves into one function that each game populates with its own linkvars, shared by the startup hook and the hotkey.

Also fixes MGS3's GM_LoadRequest which was aligned badly (possible issue elsewhere..)