### PR TITLE
Manifest fixes again

### DIFF
--- a/src/features/expand_bp_assets.cpp
+++ b/src/features/expand_bp_assets.cpp
@@ -10,7 +10,10 @@
 #include "logging.hpp"
 
 typedef long long (__fastcall* FASTCALL_1IN1OUT)(void*);
+typedef void* (__fastcall* FASTCALL_2IN1OUT)(void*, size_t);
 typedef void* (__fastcall* FASTCALL_3IN1OUT)(void*, void*, size_t);
+
+#define debug(...) do { if (g_Logging.bVerboseLogging) { spdlog::info("BPFilesysChanges: " __VA_ARGS__); } } while (0)
 
 // core components of struct; original definition in system/libfs/loader_flatfs.h
 typedef struct {
@@ -35,6 +38,8 @@ namespace {
 	//FASTCALL_3IN1OUT BPReadFile;
 	FASTCALL_1IN1OUT BPCloseFile;
 	//FASTCALL_1IN1OUT BPIsReadDone;
+	FASTCALL_1IN1OUT* MGSMalloc;
+	//FASTCALL_1IN1OUT* MGSFree;
 }
 
 // Helper for optimized file buffer allocation
@@ -45,11 +50,31 @@ static inline size_t RoundUp(size_t size) {
 	return ret;
 }
 
+static inline void* MGSRealloc(void* oldBuf, size_t newSize) {
+	//void* newBuf = (void*)(*MGSMalloc)((void*)newSize);
+	//memcpy(newBuf, oldBuf, oldSize);
+	//(*MGSFree)(oldBuf);
+	//return newBuf;
+	// 
+	// Get game realloc function relatively from the table that holds malloc.
+	return ((FASTCALL_2IN1OUT)(MGSMalloc[2]))(oldBuf, newSize);
+}
+
 // Key on the cache fields, not the source path. One texture can be registered against
 // several tri groups, and those lines differ only in the last field.
 static inline std::string_view CacheKey(const std::string& line) {
 	const size_t comma = line.find(',');
 	return comma == std::string::npos ? std::string_view(line) : std::string_view(line).substr(comma + 1);
+}
+
+static inline std::string_view GetExtension(const std::string& line) {
+	const size_t period = line.find_last_of('.');
+	if (period == std::string::npos) {
+		return std::string_view(line);
+	}
+	else {
+		return std::string_view(line).substr(period + 1);
+	}
 }
 
 static void SplitLines(const char* data, size_t size, std::vector<std::string>& out) {
@@ -118,6 +143,7 @@ static std::filesystem::path OverloadMirror(const std::filesystem::path& directo
 
 static inline void* LoadSimilarFiles(BPLoadFileState* state, bool isBPAssets) {
 #define match_substr (isBPAssets ? "bp_assets_" : "manifest_")
+	debug("loading a {}", isBPAssets ? "bp_assets" : "manifest");
 
 	// Find files similar to the currently used path.
 	const char* filePath = isBPAssets ? state->bpAssetsPath : state->manifestPath;
@@ -146,22 +172,24 @@ static inline void* LoadSimilarFiles(BPLoadFileState* state, bool isBPAssets) {
 		if (entry_path.stem().string().starts_with(match_substr)
 			&& entry_path.extension() == ".txt") {
 			// Match found, load it
-			// Need to update: buffer, file size, file handle
-			BPCloseFile(state->currentFileHandle);
-			state->currentFileHandle = (void*)BPOpenFile((void*)entry_path.string().c_str());
-			size_t newFileSize = BPGetFileSize(state->currentFileHandle);
+			// Need to update: buffer, file size, NOT file handle
+			//BPCloseFile(state->currentFileHandle);
+			//state->currentFileHandle = (void*)BPOpenFile((void*)entry_path.string().c_str());
+			// The Master Collection file reader is asynchronous. We need more consistency than that.
+			FILE* fp = fopen(entry_path.string().c_str(), "rb");
+			fseek(fp, 0, SEEK_END);
+			size_t newFileSize = ftell(fp);
+			fseek(fp, 0, SEEK_SET);
 			size_t newBufferSize = RoundUp(state->currentFileSize + newFileSize + 1);
 			if (newBufferSize > prevBufferSize) {
+				debug("reallocing");
 				char* oldBuf = *buffer;
-				*buffer = (char*)realloc(oldBuf, newBufferSize);
-				//spdlog::info("buffer for {} was at {}, now {}", filePath, (long long)oldBuf, (long long)*buffer);
+				*buffer = (char*)MGSRealloc(oldBuf, newBufferSize);
+				debug("buffer for {} was at {}, now {}", filePath, (void*)oldBuf, (void*)*buffer);
 				(*buffer)[state->currentFileSize + newFileSize] = '\0';
 			}
 			prevBufferSize = newBufferSize;
-			// Oh, and read the new file, of course.
-			//state->currentFileHandle = BPReadFile(state->currentFileHandle, &(*buffer)[state->currentFileSize], newFileSize);
-			// The Master Collection file reader is asynchronous. We need more consistency than that.
-			FILE* fp = fopen(entry_path.string().c_str(), "rb");
+			// And read the new file, of course.
 			fread(&(*buffer)[state->currentFileSize], newFileSize, 1, fp);
 			fclose(fp);
 			if ((*buffer)[state->currentFileSize] == '\0')
@@ -179,41 +207,71 @@ static inline void* LoadSimilarFiles(BPLoadFileState* state, bool isBPAssets) {
 	// motion. New entries go on the end: the list is in dependency order.
 	size_t newFilesSize = state->currentFileSize - originalFileSize;
 	if (newFilesSize) {
-		std::vector<std::string> lines, extra;
-		SplitLines(*buffer, originalFileSize, lines);
-		SplitLines(&(*buffer)[originalFileSize], newFilesSize, extra);
+		std::vector<std::string> lines;
+		SplitLines(*buffer, state->currentFileSize, lines);
+
+		// Sort lines by asset type and remove duplicates (later entry prioritized)
+		typedef std::pair<std::string, std::vector<std::string>> LineGroup;
+		std::vector<LineGroup> sortedLines = {
+			{"tri", {}},
+			{"hzx", {}},
+			{"var", {}},
+			{"sar", {}},
+			{"row", {}},
+			{"mar", {}},
+			{"lt2", {}},
+			{"kms", {}},
+			{"evm", {}},
+			{"cv2", {}},
+			{"gcx", {}},
+			{"ctxr", {}},
+			{"cmdl", {}},
+			{"other", {}} // Extension-match iterator defaults to this
+		};
 
 		size_t replaced = 0, added = 0;
-		for (const std::string& line : extra) {
+		for (const std::string& line : lines) {
+			// Get appropriate vector 
+			const std::string_view extension = GetExtension(line);
+			// std::prev causes fallback case to be "other" rather than sortedLines.end()
+			auto matchGroup = std::find_if(sortedLines.begin(), std::prev(sortedLines.end()),
+				[&](const LineGroup& v) { return v.first == extension; });
+			std::vector<std::string>& lineVec = (*matchGroup).second;
+
+			// Insert into vector, with duplicate cleanup
 			const std::string_view key = CacheKey(line);
-			auto match = std::find_if(lines.begin(), lines.end(),
+			auto match = std::find_if(lineVec.begin(), lineVec.end(),
 				[&](const std::string& v) { return CacheKey(v) == key; });
-			if (match != lines.end()) {
+			if (match != lineVec.end()) {
 				*match = line;
 				replaced++;
 			}
 			else {
-				lines.push_back(line);
 				added++;
+				lineVec.push_back(line);
 			}
 		}
 
 		std::string merged;
-		merged.reserve(state->currentFileSize + 2 * lines.size() + 1);
-		for (const std::string& line : lines) {
-			merged += line;
-			merged += "\r\n";
+		merged.reserve(state->currentFileSize + lines.size() + 1);
+		for (const LineGroup& group : sortedLines) {
+			for (const std::string& line : group.second) {
+				merged += line;
+				// Unix newline is slightly more optimal as the game's parser discards CR.
+				merged += "\n";
+			}
 		}
 
 		const size_t needed = RoundUp(merged.size() + 1);
 		if (needed > prevBufferSize) {
-			*buffer = (char*)realloc(*buffer, needed);
+			spdlog::warn("BPFilesysChanges: Unexpected reallocation (should have had space already?)");
+			*buffer = (char*)MGSRealloc(*buffer, needed);
 		}
 		memcpy(*buffer, merged.data(), merged.size());
 		(*buffer)[merged.size()] = '\0';
 		state->currentFileSize = merged.size();
 		spdlog::info("{}: merged {} supplementary entries ({} replaced, {} added)",
-			std::filesystem::path(filePath).filename().string(), extra.size(), replaced, added);
+			std::filesystem::path(filePath).filename().string(), replaced + added, replaced, added);
 	}
 
 	return state->currentFileHandle;
@@ -253,23 +311,21 @@ void BP_FilesysChanges::Initialize() {
 	BPOpenFile = (FASTCALL_1IN1OUT)Memory::GetRelativeOffset(BPAssetsLoader + 0x91);
 	BPGetFileSize = (FASTCALL_1IN1OUT)Memory::GetRelativeOffset(BPAssetsLoader + 0xa6);
 	//BPReadFile = (FASTCALL_3IN1OUT)Memory::GetRelativeOffset(BPAssetsLoader + 0x10f);
+	MGSMalloc = (FASTCALL_1IN1OUT*)Memory::GetRelativeOffset(BPAssetsLoader + 0xe3);
+	//MGSFree = (FASTCALL_1IN1OUT*)Memory::GetRelativeOffset(BPAssetsLoader + 0x1e2);
 
 
-	// Both these injections are immediately after the file is read in; we can close the handle and open new ones as needed.
-	// system/libfs/loader_flatfs.cpp -> BP_BeginLoadFlatFS()
-	{
-		MAKE_HOOK_MID(baseModule, "48 89 83 50 05 00 00 48 83 C4 20 5B C3", "manifest.txt Union", {
-			// rax = file handle
-			// rbx = load state struct
-			ctx.rax = (uintptr_t)LoadSimilarFiles((BPLoadFileState*)ctx.rbx, false);
-		});
-	}
+	// Both these injections are immediately before the file is closed; we realloc and add data to the buffer.
 	// system/libfs/loader_flatfs.cpp -> BP_LoadFlatFSSync()
 	{
-		MAKE_HOOK_MID(baseModule, "48 89 87 ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? 48 8B 8F ?? ?? ?? ?? E8", "bp_assets.txt Union", {
-			// rax = file handle
+		MAKE_HOOK_MID(baseModule, "E8 ?? ?? ?? ?? 48 8B 87 08 01 00 00 48 8D 8F 18 01 00 00", "manifest.txt Union", {
 			// rdi = load state struct
-			ctx.rax = (uintptr_t)LoadSimilarFiles((BPLoadFileState*)ctx.rdi, true);
+			LoadSimilarFiles((BPLoadFileState*)ctx.rdi, false);
+		});
+
+		MAKE_HOOK_MID(baseModule, "E8 ?? ?? ?? ?? 48 8B 87 20 02 00 00 B9 10 57 00 00", "bp_assets.txt Union", {
+			// rdi = load state struct
+			LoadSimilarFiles((BPLoadFileState*)ctx.rdi, true);
 		});
 	}
 }

--- a/src/features/expand_bp_assets.cpp
+++ b/src/features/expand_bp_assets.cpp
@@ -284,14 +284,6 @@ void BP_FilesysChanges::Initialize() {
 		return;
 	}
 
-	if (Util::IsSteamOS()) // temporary. linux filesystems are stupid and shit reliant on expand_bp_assets can randomly cause crashing.
-	{
-        spdlog::warn("BP_FilesysChanges: Temporarily disabled on SteamOS due to crashing issues with Linux filesystems.");
-        spdlog::warn("BP_FilesysChanges: Features reliant on expand_bp_assets will not be available.");
-        spdlog::warn("BP_FilesysChanges: This includes: Snake Holster Fix, Hostage Arm Fix, Shell 1 Core Camera Screen fix, Alternative Colonel MSX Sprite.");
-		return;
-	}
-
 	bLoaded = true;
 
 	// The HD Collection (hence, the Master Collection) have a different file system to the original games.

--- a/src/features/expand_bp_assets.cpp
+++ b/src/features/expand_bp_assets.cpp
@@ -44,7 +44,7 @@ namespace {
 
 // Helper for optimized file buffer allocation
 static inline size_t RoundUp(size_t size) {
-	int ret = 1;
+	size_t ret = 1;
 	while (ret < size)
 		ret <<= 1;
 	return ret;
@@ -176,11 +176,17 @@ static inline void* LoadSimilarFiles(BPLoadFileState* state, bool isBPAssets) {
 			//BPCloseFile(state->currentFileHandle);
 			//state->currentFileHandle = (void*)BPOpenFile((void*)entry_path.string().c_str());
 			// The Master Collection file reader is asynchronous. We need more consistency than that.
-			FILE* fp = fopen(entry_path.string().c_str(), "rb");
+			FILE* fp = _wfopen(entry_path.c_str(), L"rb");
+			if (!fp) {
+				spdlog::warn("BPFilesysChanges: Failed to open {} with error \"{}\". Skipping.", entry_path.string(), strerror(errno));
+				continue;
+			}
 			fseek(fp, 0, SEEK_END);
 			size_t newFileSize = ftell(fp);
 			fseek(fp, 0, SEEK_SET);
-			size_t newBufferSize = RoundUp(state->currentFileSize + newFileSize + 1);
+			// In case a file is missing its trailing newline, make sure to insert that before it causes problems.
+			bool needNewline = state->currentFileSize && (*buffer)[state->currentFileSize - 1] != '\n';
+			size_t newBufferSize = RoundUp(state->currentFileSize + newFileSize + 1 + needNewline);
 			if (newBufferSize > prevBufferSize) {
 				debug("reallocing");
 				char* oldBuf = *buffer;
@@ -190,8 +196,14 @@ static inline void* LoadSimilarFiles(BPLoadFileState* state, bool isBPAssets) {
 			}
 			prevBufferSize = newBufferSize;
 			// And read the new file, of course.
+			if (needNewline) {
+				debug("Newline added.");
+				(*buffer)[state->currentFileSize] = '\n';
+				state->currentFileSize++;
+			}
 			fread(&(*buffer)[state->currentFileSize], newFileSize, 1, fp);
 			fclose(fp);
+
 			if ((*buffer)[state->currentFileSize] == '\0')
 			{
 				// ??? mission failed? what?

--- a/src/features/mgs2_msx_colonel.cpp
+++ b/src/features/mgs2_msx_colonel.cpp
@@ -36,8 +36,7 @@ void MGS2RetroColonel::Initialize()
 #define TEXTURE_EU_JP(X) (exists(sExePath / "textures" / "flatlist" / "ovr_stm" / "ovr_eu" / X) \
                           && exists(sExePath / "textures" / "flatlist" / "ovr_stm" / "ovr_jp" / X))
 
-    if (BP_FilesysChanges::bLoaded && //linux filesystems are stupid and shit reliant on expand_bp_assets can randomly cause crashing.
-        g_MGS2RetroColonel.bUseNewSprite
+    if (g_MGS2RetroColonel.bUseNewSprite
         && exists(sExePath / "assets" / "tri" / "us" / "spacecore_taisa.tri")
         && TEXTURE_EU_JP("_win" / "spacecore_taisa_subsist_alp_ovl.bmp.ctxr")
         && EU_JP("face" / "f01e" / "manifest_cbfc_spacecore_msx_subsis.txt")
@@ -55,8 +54,7 @@ void MGS2RetroColonel::Initialize()
         camPosList[1][4] = 6;
         camPosList[1][5] = 10796;
     }
-    else if (BP_FilesysChanges::bLoaded && //linux filesystems are stupid and shit reliant on expand_bp_assets can randomly cause crashing.
-             g_MGS2RetroColonel.bUseNewSprite)
+    else if (g_MGS2RetroColonel.bUseNewSprite)
     {
         spdlog::warn("MGS2: MG2 Colonel Sprite: MGS2 Community Bugfix Compilation files missing. Using original sprite and position.");
     }

--- a/src/fixes/mgs2_hostage_model.cpp
+++ b/src/fixes/mgs2_hostage_model.cpp
@@ -23,11 +23,6 @@ void HostageModel::ApplyFix()
         return;
     }
 
-    if (!BP_FilesysChanges::bLoaded) //linux filesystems are stupid and shit reliant on expand_bp_assets can randomly cause crashing.
-    {
-        return;
-    }
-
     // Depends on custom models (provided by community bugfix pack)
 #define EU_JP(X) (exists(sExePath / "eu" / X) && exists(sExePath / "jp" / X))
 

--- a/src/fixes/texture_live_swaps.cpp
+++ b/src/fixes/texture_live_swaps.cpp
@@ -220,8 +220,7 @@ void TextureLiveSwaps::ApplyFixes()
 #define TEXTURE_EU_JP(X) (exists(sExePath / "textures" / "flatlist" / "ovr_stm" / "ovr_eu" / X) \
                           && exists(sExePath / "textures" / "flatlist" / "ovr_stm" / "ovr_jp" / X))
 
-    if (BP_FilesysChanges::bLoaded && //linux filesystems are stupid and shit reliant on expand_bp_assets can randomly cause crashing.
-        exists(sExePath / "assets" / "tri" / "us" / "spacecore_w24c1.tri")
+    if (exists(sExePath / "assets" / "tri" / "us" / "spacecore_w24c1.tri")
         && TEXTURE_EU_JP("_win" / "spacecore_w24c1_rev_disp_02.bmp.ctxr")
         && EU_JP("stage" / "d036p03" / "manifest_cbfc_hostage_fixes.txt")
         && EU_JP("stage" / "d036p03" / "bp_assets_cbfc_hostage_fixes.txt"))
@@ -268,8 +267,7 @@ void TextureLiveSwaps::ApplyFixes()
     }
 
 
-    if (BP_FilesysChanges::bLoaded && //linux filesystems are stupid and shit reliant on expand_bp_assets can randomly cause crashing.
-        EU_JP("stage" / "r_sna_b" / "bp_assets_holster_fix.txt") &&
+    if (EU_JP("stage" / "r_sna_b" / "bp_assets_holster_fix.txt") &&
         EU_JP("stage" / "r_tnk0" / "bp_assets_holster_fix.txt") &&
         EU_JP("stage" / "r_plt_s" / "bp_assets_holster_fix.txt") &&
         EU_JP("stage" / "r_vr_s" / "bp_assets_holster_fix.txt") &&


### PR DESCRIPTION
Fix manifest loading:

- Use the game's realloc function rather than HDFix's, should ensure compatibility between memory regions on Proton (tested on Linux Mint).
- When merging files, sort by the extension of each asset to ensure dependencies are met with both new and old files. Extension list created by just looking at w24b/manifest.txt so may be missing some types, which will default to the end. New assets still get priority as replacements, though the duplicate handling is not otherwise vanilla and will prioritize the latter of a set of duplicates should it exist rather than the former.
- Avoid messing with the file handle the game is using, leave it pointed to the original file and handle all else with fopen/fread/fclose (previously used fopen/fread/fclose for reading, but BP_GetFileSize to get the file size, modifying the handle in the process).
- Move injection to before BP_CloseFile rather than after BP_ReadFileAsync, as the original case had sometimes resulted in an incomplete read when HDFix processed additions.
- As a result of all of this, re-enable manifest and bp_assets expansion on Linux and SteamOS.

Tested w24b (Shell 1 Core B1), w24c (Shell 1 Core Conference Room), and d080p07 (Arsenal Approaches) with various mods to manifest and bp_assets for each, all appeared fine.