### PR TITLE
MGS2: restore the scripted slow motion

### DIFF
--- a/src/fixes/effect_speeds.cpp
+++ b/src/fixes/effect_speeds.cpp
@@ -979,7 +979,7 @@ void EffectSpeedFix::Initialize()
     }
 
     if (uint8_t* slowDownAct = Memory::PatternScan(baseModule,
-        "40 53 48 83 EC 20 8B 05 ?? ?? ?? ?? 48 8B D9 0B 05 ?? ?? ?? ?? 7D ?? C7 05 ?? ?? ?? ?? 00 00 00 00",
+        "40 53 48 83 EC ?? 8B 05 ?? ?? ?? ?? 48 8B D9 0B 05 ?? ?? ?? ?? 7D",
         "MGS 2: Effect Speed Fix : user\\okajima\\effect\\slowdown.c -> Act()"))
     {
         h_SlowDownAct = safetyhook::create_mid(slowDownAct, SlowDownAct_hook);
@@ -987,7 +987,7 @@ void EffectSpeedFix::Initialize()
     }
 
     if (uint8_t* exec = Memory::PatternScan(baseModule,
-        "BE 0C 00 00 00 48 8D 2D ?? ?? ?? ?? 66 0F 1F 84 00 00 00 00 00 8B 05 ?? ?? ?? ?? A8 20 74 ?? 48 3B FD 74 ?? 83 C8 01 85 47 70 75 ?? 48 8B 0F 66 0F 1F 44 00 00 F7 41 10 00 00 0F 00 48 8B 19 75 ?? 48 8B 41 08 48 85 C0 74 ?? FF D0 48 8B CB 48 85 DB 75 ?? 48 83 C7 78 FF CE 85 F6 7F ??",
+        "BE ?? ?? ?? ?? 48 8D 2D ?? ?? ?? ?? 66 0F 1F 84 00",
         "MGS 2: Effect Speed Fix : system\\libgv\\actor.c -> GV_ExecActorSystem()"))
     {
         // Pattern ends on the loop's jg, so the epilogue is right after it.

--- a/src/fixes/effect_speeds.cpp
+++ b/src/fixes/effect_speeds.cpp
@@ -213,7 +213,8 @@ private:
 // DG_FrameCount==2 = the game's own "this section ran 30fps on PS2" flag. More reliable
 // than InCutscene() - demo blips set 1, real 30fps windows set 2.
 inline int* g_pWindowFrameCount = nullptr;
-inline bool In30fpsWindow() { return g_pWindowFrameCount && *g_pWindowFrameCount == 2; }
+inline bool g_slowDownDriving = false;
+inline bool In30fpsWindow() { return !g_slowDownDriving && g_pWindowFrameCount && *g_pWindowFrameCount == 2; }
 
 // Ribbons born inside a real 30fps window, latched at spawn. Fixed-size and alloc-free on
 // purpose: hook bodies must never allocate. Slot collisions just drop a latch early (the
@@ -592,6 +593,41 @@ namespace
         return In30fpsWindow() && (g_GameVars.DG_Clock() & 1) != 0;
     }
 
+    // Scripted slow motion. slowdown.c asks for N vsyncs a frame and the PS2 waited them out, so skip
+    // the whole actor pass on N-1 frames in N. Holding only part of it desyncs the game.
+    SafetyHookMid h_SlowDownAct {};
+    SafetyHookMid h_ExecActorSystem {};
+    uintptr_t g_execActorSystemDone = 0;
+    int g_slowDownPhase = 0;
+
+    void SlowDownAct_hook(SafetyHookContext&)
+    {
+        g_slowDownDriving = true;
+    }
+
+    void ExecActorSystem_hook(SafetyHookContext& ctx)
+    {
+        const int frames = g_pWindowFrameCount ? *g_pWindowFrameCount : 0;
+        if (frames < 2)
+        {
+            g_slowDownDriving = false;
+            g_slowDownPhase = 0;
+            return;
+        }
+
+        // 30fps demo windows write the same flag, and those stay at 60.
+        if (!g_slowDownDriving)
+        {
+            return;
+        }
+
+        g_slowDownPhase = (g_slowDownPhase + 1) % frames;
+        if (g_slowDownPhase != 0)
+        {
+            ctx.rip = g_execActorSystemDone;
+        }
+    }
+
     // t00a2d bridge traffic. traffic.c moves the cars a fixed step per Act, so they run at the port's
     // rate, not the 30fps the demo was authored at. Hold every other frame.
     SafetyHookMid h_TrafficDemoAct {};
@@ -940,6 +976,25 @@ void EffectSpeedFix::Initialize()
     else
     {
         spdlog::error("MGS 2: Effect Speed Fix : rain_slow.c - Failed to find rain_slow copyback address, rain_slow.c frameskip is disabled.");
+    }
+
+    if (uint8_t* slowDownAct = Memory::PatternScan(baseModule,
+        "40 53 48 83 EC 20 8B 05 ?? ?? ?? ?? 48 8B D9 0B 05 ?? ?? ?? ?? 7D ?? C7 05 ?? ?? ?? ?? 00 00 00 00",
+        "MGS 2: Effect Speed Fix : user\\okajima\\effect\\slowdown.c -> Act()"))
+    {
+        h_SlowDownAct = safetyhook::create_mid(slowDownAct, SlowDownAct_hook);
+        LOG_HOOK(h_SlowDownAct, "MGS 2: Effect Speed Fix : slowdown.c -> Act()")
+    }
+
+    if (uint8_t* exec = Memory::PatternScan(baseModule,
+        "BE 0C 00 00 00 48 8D 2D ?? ?? ?? ?? 66 0F 1F 84 00 00 00 00 00 8B 05 ?? ?? ?? ?? A8 20 74 ?? 48 3B FD 74 ?? 83 C8 01 85 47 70 75 ?? 48 8B 0F 66 0F 1F 44 00 00 F7 41 10 00 00 0F 00 48 8B 19 75 ?? 48 8B 41 08 48 85 C0 74 ?? FF D0 48 8B CB 48 85 DB 75 ?? 48 83 C7 78 FF CE 85 F6 7F ??",
+        "MGS 2: Effect Speed Fix : system\\libgv\\actor.c -> GV_ExecActorSystem()"))
+    {
+        // Pattern ends on the loop's jg, so the epilogue is right after it.
+        g_execActorSystemDone = reinterpret_cast<uintptr_t>(exec) + 0x5E;
+
+        h_ExecActorSystem = safetyhook::create_mid(exec, ExecActorSystem_hook);
+        LOG_HOOK(h_ExecActorSystem, "MGS 2: Effect Speed Fix : actor.c -> GV_ExecActorSystem()")
     }
 
     // The port's own frame gate for the traffic Act: skip the car update on 4 frames in 5.


### PR DESCRIPTION
When Olga dies, and few spots like Vamps death in the pool we have some scripted slowdowns. Olga no longer dramatically dies in full speed :)